### PR TITLE
Properly Update `position.feeGrowthInsideLast` for fungible positions

### DIFF
--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -84,7 +84,7 @@ contract RangePool is
                 )
         );
         uint256 liquidityMinted;
-        (params, liquidityMinted) = Positions.validate(params, pool);
+        (params, liquidityMinted) = Positions.validate(params, pool, _immutables());
         if (params.amount0 > 0) _transferIn(token0, params.amount0);
         if (params.amount1 > 0) _transferIn(token1, params.amount1);
         if (position.amount0 > 0 || position.amount1 > 0) {
@@ -186,8 +186,8 @@ contract RangePool is
                 )
             );
         }
-        _transferOut(params.to, token0, amount0);
-        _transferOut(params.to, token1, amount1);
+        if (amount0 > 0) _transferOut(params.to, token0, amount0);
+        if (amount1 > 0) _transferOut(params.to, token1, amount1);
         poolState = pool;
         positions[params.fungible ? address(this) : msg.sender][
             params.lower
@@ -199,9 +199,12 @@ contract RangePool is
         bool zeroForOne,
         uint256 amountIn,
         uint160 priceLimit
-    ) external override lock
+    ) external override lock returns(
+        int256,
+        int256
+    )
     {
-        if (amountIn == 0) return;
+        if (amountIn == 0) return (0,0);
         _transferIn(zeroForOne ? token0 : token1, amountIn);
         PoolState memory pool = poolState;
         SwapCache memory cache;
@@ -247,8 +250,9 @@ contract RangePool is
         uint256 amountIn,
         uint160 priceLimit
     ) external view override returns (
-        PoolState memory,
-        SwapCache memory
+        uint256,
+        uint256,
+        uint160
     ) {
         // figure out price limit for user
         // quote with low price limit
@@ -265,9 +269,11 @@ contract RangePool is
             amountIn,
             pool
         );
-        cache.input  = amountIn - cache.input;
-        cache.output = cache.output;
-        return (pool, cache);
+        return (
+            amountIn - cache.input,
+            cache.output,
+            pool.price
+        );
     }
 
     function collectProtocolFees() external lock returns (
@@ -280,6 +286,13 @@ contract RangePool is
         poolState.protocolFees.token1 = 0;
         _transferOut(owner.feeTo(), token0, token0Fees);
         _transferOut(owner.feeTo(), token1, token1Fees);
+    }
+
+    function _immutables() private view returns (Immutables memory) {
+        return Immutables(
+            swapFee,
+            tickSpacing
+        );
     }
 
     function _prelock() private {

--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -71,7 +71,6 @@ contract RangePool is
         Position memory position = positions[params.fungible ? address(this) 
                                                              : params.to]
                                             [params.lower][params.upper];
-        console.log('mint fee growth', pool.feeGrowthGlobal1);
         (position, , ) = Positions.update(
                 ticks,
                 position,

--- a/contracts/base/events/RangePoolEvents.sol
+++ b/contracts/base/events/RangePoolEvents.sol
@@ -58,6 +58,6 @@ abstract contract RangePoolEvents {
         uint256 amountOut,
         uint160 price,
         uint128 liquidity,
-        int24 nearestTick
+        int24 tickAtPrice
     );
 }

--- a/contracts/interfaces/IRangePool.sol
+++ b/contracts/interfaces/IRangePool.sol
@@ -14,15 +14,19 @@ interface IRangePool is IRangePoolStructs {
         bool zeroForOne,
         uint256 amountIn,
         uint160 priceLimit
-    ) external;
+    ) external returns (
+        int256 amount0,
+        int256 amount1
+    );
 
     function quote(
         bool zeroForOne,
         uint256 amountIn,
         uint160 priceLimit
     ) external view returns (
-        PoolState memory,
-        SwapCache memory
+        uint256 inAmount,
+        uint256 outAmount,
+        uint160 priceAfter
     );
 
     function increaseSampleLength(

--- a/contracts/interfaces/IRangePool.sol
+++ b/contracts/interfaces/IRangePool.sol
@@ -25,7 +25,11 @@ interface IRangePool is IRangePoolStructs {
         SwapCache memory
     );
 
-    function collectFees() external returns (
+    function increaseSampleLength(
+        uint16 sampleLengthNext
+    ) external;
+
+    function collectProtocolFees() external returns (
         uint128 token0Fees,
         uint128 token1Fees
     );

--- a/contracts/interfaces/IRangePoolStructs.sol
+++ b/contracts/interfaces/IRangePoolStructs.sol
@@ -64,6 +64,11 @@ interface IRangePoolStructs {
         uint128 token1;
     }
 
+    struct Immutables {
+        uint16 swapFee;
+        int24  tickSpacing;
+    }
+
     //TODO: take out fungible option
     struct MintParams {
         address to;

--- a/contracts/interfaces/IRangePoolStructs.sol
+++ b/contracts/interfaces/IRangePoolStructs.sol
@@ -6,7 +6,7 @@ import "./IRangePoolERC1155.sol";
 interface IRangePoolStructs {
     struct PoolState {
         uint8   unlocked;
-        int24   nearestTick;
+        int24   tickAtPrice;
         uint32  secondsGrowthGlobal; /// @dev Multiplied by 2^128
         int56   tickSecondsAccum;
         uint160 secondsPerLiquidityAccum;
@@ -64,6 +64,7 @@ interface IRangePoolStructs {
         uint128 token1;
     }
 
+    //TODO: take out fungible option
     struct MintParams {
         address to;
         int24 lower;
@@ -137,11 +138,12 @@ interface IRangePoolStructs {
         int24   crossTick;
         uint16  swapFee;
         uint16  protocolFee;
+        int56   tickSecondsAccum;
+        uint160 secondsPerLiquidityAccum;
+        uint160 crossPrice;
         uint256 input;
         uint256 output;
         uint256 amountIn;
-        int56   tickSecondsAccum;
-        uint160 secondsPerLiquidityAccum;
     }
 
     struct PositionCache {

--- a/contracts/libraries/FeeMath.sol
+++ b/contracts/libraries/FeeMath.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.13;
 
 import "./PrecisionMath.sol";
 import "../interfaces/IRangePoolStructs.sol";
-import 'hardhat/console.sol';
 
 /// @notice Math library that facilitates fee handling.
 library FeeMath {
@@ -14,7 +13,7 @@ library FeeMath {
         IRangePoolStructs.SwapCache memory cache,
         uint256 amountOut,
         bool zeroForOne
-    ) internal view returns (
+    ) internal pure returns (
             IRangePoolStructs.PoolState memory,
             IRangePoolStructs.SwapCache memory
         )
@@ -24,23 +23,14 @@ library FeeMath {
         uint256 protocolFee = PrecisionMath.mulDivRoundingUp(feeAmount, cache.protocolFee, 1e6);
         amountOut -= feeAmount;
         feeAmount -= protocolFee;
-        console.log('fee check: ', feeAmount);
 
         if (zeroForOne) {
            pool.protocolFees.token1 += uint128(protocolFee);
-           console.log('fee growth 1 before', pool.feeGrowthGlobal1);
-        //    if (pool.feeGrowthGlobal1 == 34292938811045563981883043566955) pool.feeGrowthGlobal1 += 34292938811045563981883043566955;
            pool.feeGrowthGlobal1 += uint200(PrecisionMath.mulDiv(feeAmount, Q128, pool.liquidity));
-            console.log('fee growth 1 after', pool.feeGrowthGlobal1);
         } else {
           pool.protocolFees.token0 += uint128(protocolFee);
           pool.feeGrowthGlobal0 += uint200(PrecisionMath.mulDiv(feeAmount, Q128, pool.liquidity));
         }
-                console.log('back check fee: ', PrecisionMath.mulDiv(
-                uint200(PrecisionMath.mulDiv(feeAmount, Q128, pool.liquidity)),
-                uint256(pool.liquidity),
-                Q128
-            ));
         cache.output += amountOut;
         return (pool, cache);
     }

--- a/contracts/libraries/FeeMath.sol
+++ b/contracts/libraries/FeeMath.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.13;
 
 import "./PrecisionMath.sol";
 import "../interfaces/IRangePoolStructs.sol";
+import 'hardhat/console.sol';
 
 /// @notice Math library that facilitates fee handling.
 library FeeMath {
@@ -11,24 +12,36 @@ library FeeMath {
     function calculate(
         IRangePoolStructs.PoolState memory pool,
         IRangePoolStructs.SwapCache memory cache,
+        uint256 amountOut,
         bool zeroForOne
-    ) internal pure returns (
+    ) internal view returns (
             IRangePoolStructs.PoolState memory,
             IRangePoolStructs.SwapCache memory
         )
     {
         if (pool.liquidity == 0 ) return (pool, cache);
-        uint256 feeAmount = PrecisionMath.mulDivRoundingUp(cache.output, cache.swapFee, 1e6); 
+        uint256 feeAmount = PrecisionMath.mulDivRoundingUp(amountOut, cache.swapFee, 1e6); 
         uint256 protocolFee = PrecisionMath.mulDivRoundingUp(feeAmount, cache.protocolFee, 1e6);
-        cache.output -= feeAmount;
+        amountOut -= feeAmount;
         feeAmount -= protocolFee;
+        console.log('fee check: ', feeAmount);
+
         if (zeroForOne) {
            pool.protocolFees.token1 += uint128(protocolFee);
+           console.log('fee growth 1 before', pool.feeGrowthGlobal1);
+        //    if (pool.feeGrowthGlobal1 == 34292938811045563981883043566955) pool.feeGrowthGlobal1 += 34292938811045563981883043566955;
            pool.feeGrowthGlobal1 += uint200(PrecisionMath.mulDiv(feeAmount, Q128, pool.liquidity));
+            console.log('fee growth 1 after', pool.feeGrowthGlobal1);
         } else {
           pool.protocolFees.token0 += uint128(protocolFee);
           pool.feeGrowthGlobal0 += uint200(PrecisionMath.mulDiv(feeAmount, Q128, pool.liquidity));
         }
+                console.log('back check fee: ', PrecisionMath.mulDiv(
+                uint200(PrecisionMath.mulDiv(feeAmount, Q128, pool.liquidity)),
+                uint256(pool.liquidity),
+                Q128
+            ));
+        cache.output += amountOut;
         return (pool, cache);
     }
 }

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -75,8 +75,11 @@ library Positions {
 
     function validate(
         IRangePoolStructs.MintParams memory params,
-        IRangePoolStructs.PoolState memory state
+        IRangePoolStructs.PoolState memory state,
+        IRangePoolStructs.Immutables memory constants
     ) external pure returns (IRangePoolStructs.MintParams memory, uint256 liquidityMinted) {
+        Ticks.validate(params.lower, params.upper, constants.tickSpacing);
+        
         uint256 priceLower = uint256(TickMath.getSqrtRatioAtTick(params.lower));
         uint256 priceUpper = uint256(TickMath.getSqrtRatioAtTick(params.upper));
 

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -132,6 +132,17 @@ library Positions {
             params.amount
         );
 
+        (
+            position.feeGrowthInside0Last,
+            position.feeGrowthInside1Last
+        ) = rangeFeeGrowth(
+            ticks[params.mint.lower],
+            ticks[params.mint.upper],
+            params.state,
+            params.mint.lower,
+            params.mint.upper
+        );
+
         if (cache.priceLower < params.state.price && params.state.price < cache.priceUpper) {
             params.state.liquidity += params.amount;
         }
@@ -360,8 +371,6 @@ library Positions {
             params.upper
         );
 
-        if (params.amount > 0) console.log('fee growth check 1', rangeFeeGrowth1, position.feeGrowthInside1Last);
-
         uint128 amount0Fees = uint128(
             PrecisionMath.mulDiv(
                 rangeFeeGrowth0 - position.feeGrowthInside0Last,
@@ -378,10 +387,6 @@ library Positions {
             )
         );
 
-        console.log('amount 1 fees:', amount1Fees);
-
-        if (params.amount == 0) console.log('mint check 0:', position.feeGrowthInside0Last, rangeFeeGrowth0);
-        if (params.amount == 0) console.log('mint check 1:', position.feeGrowthInside1Last, rangeFeeGrowth1);
         position.feeGrowthInside0Last = rangeFeeGrowth0;
         position.feeGrowthInside1Last = rangeFeeGrowth1;
 

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -32,6 +32,11 @@ library Samples {
             secondsPerLiquidityAccum: 0
         });
 
+        emit SampleRecorded(
+            0,
+            0
+        );
+
         state.samples.length = 1;
         state.samples.lengthNext = 5;
 

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -92,7 +92,7 @@ library TickMap {
                 if (block_ == 0) {
                     uint256 blockMap = tickMap.blocks & ((1 << blockIndex) - 1);
                     // assert(blockMap != 0);
-                    // if blockMap == 0 return type(int24).min() or MIN_TICK
+                    if (blockMap == 0) return tick;
 
                     blockIndex = _msb(blockMap);
                     block_ = tickMap.words[blockIndex];

--- a/contracts/utils/RangePoolManager.sol
+++ b/contracts/utils/RangePoolManager.sol
@@ -158,7 +158,7 @@ contract RangePoolManager is
     ) external onlyFeeTo {
         for (uint i; i < collectPools.length; i++) {
             uint128 token0Fees; uint128 token1Fees;
-            (token0Fees, token1Fees) = IRangePool(collectPools[i]).collectFees();
+            (token0Fees, token1Fees) = IRangePool(collectPools[i]).collectProtocolFees();
             emit ProtocolFeeCollected(collectPools[i], token0Fees, token1Fees);
         }
     }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -42,7 +42,7 @@ const config: HardhatUserConfig = {
         },
         arb_goerli: {
             chainId: 421613,
-            gasPrice: 3000000000,
+            gasPrice: 5000000000,
             url: process.env.ARBITRUM_GOERLI_URL || '',
             accounts: process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
             timeout: 60000,

--- a/scripts/autogen/contract-deployments.json
+++ b/scripts/autogen/contract-deployments.json
@@ -1,5 +1,17 @@
 {
     "arb_goerli": {
+        "token0": {
+            "contractName": "Token20",
+            "contractAddress": "0x6774be1a283Faed7ED8e40463c40Fb33A8da3461",
+            "constructorArguments": [],
+            "created": "2023-04-10T16:57:42.945Z"
+        },
+        "token1": {
+            "contractName": "Token20",
+            "contractAddress": "0xC26906E10E8BDaDeb2cf297eb56DF59775eE52c4",
+            "constructorArguments": [],
+            "created": "2023-04-10T16:57:42.945Z"
+        },
         "tickMathLib": {
             "contractName": "TickMath",
             "contractAddress": "0x09D9d80bCF681B56B804ad60728bd1927F18F43C",
@@ -50,7 +62,7 @@
         },
         "rangePoolFactory": {
             "contractName": "RangePoolFactory",
-            "contractAddress": "0x5cff06eE7c5f2eb60ECf9C7d149c668a65Dd37B1",
+            "contractAddress": "0x1598DCe2D358F652E6625039C3c12e63b0444Bef",
             "constructorArguments": [
                 "0x36c0237E687CB57C3B3A2052c56A7465C62A8AF9"
             ],
@@ -58,7 +70,7 @@
         },
         "rangePool": {
             "contractName": "RangePool",
-            "contractAddress": "0x973Dc7E4d42cC4be9BCC88affB4EBff49cA1dC4f",
+            "contractAddress": "0x51abd14047564d7e91d3604b34a9b7c1721f0ac6",
             "constructorArguments": [
                 "0x829e4a03A5Bd1EC5b6f5CC1d3A77c8e54A294847",
                 "0xf853592f1e4ceA2B5e722A17C6f917a4c70d40Ca",
@@ -67,6 +79,96 @@
                 "177159557114295710296101716160"
             ],
             "created": "2023-04-10T16:57:54.951Z"
+        }
+    },
+    "undefined": {
+        "token0": {
+            "contractName": "Token20",
+            "contractAddress": "0x189f7Ba3C382aF7a5Ff38010Cf96D29e6c5f1e12",
+            "constructorArguments": [
+                "Token20B",
+                "TOKEN20B",
+                18
+            ],
+            "created": "2023-05-03T05:03:50.457Z"
+        },
+        "token1": {
+            "contractName": "Token20",
+            "contractAddress": "0x9c0e3c8C7B1fD2FdE8e933A55864Da2A8696E3D8",
+            "constructorArguments": [
+                "Token20A",
+                "TOKEN20A",
+                18
+            ],
+            "created": "2023-05-03T05:03:50.461Z"
+        },
+        "tickMathLib": {
+            "contractName": "TickMath",
+            "contractAddress": "0x75BA6958BC4cF9a37D0d0349C223B4f400200B26",
+            "constructorArguments": [],
+            "created": "2023-05-03T05:03:52.531Z"
+        },
+        "precisionMathLib": {
+            "contractName": "PrecisionMath",
+            "contractAddress": "0x39cd45535021F6C26CF7e401cdE8Ab7b455167f1",
+            "constructorArguments": [],
+            "created": "2023-05-03T05:03:54.864Z"
+        },
+        "dydxMathLib": {
+            "contractName": "DyDxMath",
+            "contractAddress": "0xF27e44423950E9756e1c74dE8c3675803cbC9e5c",
+            "constructorArguments": [],
+            "created": "2023-05-03T05:03:57.085Z"
+        },
+        "tickMapLib": {
+            "contractName": "TickMap",
+            "contractAddress": "0xa39456118D0B7579E146dD4F9c1c9660F89737ee",
+            "constructorArguments": [],
+            "created": "2023-05-03T05:03:59.133Z"
+        },
+        "samplesLib": {
+            "contractName": "Samples",
+            "contractAddress": "0x976611BA6Da3279D5a141cCC43805c3bb88f7D16",
+            "constructorArguments": [],
+            "created": "2023-05-03T05:04:01.271Z"
+        },
+        "ticksLib": {
+            "contractName": "Ticks",
+            "contractAddress": "0x915C8485f345e7316312c6aDD9031FF7C60d3AD1",
+            "constructorArguments": [],
+            "created": "2023-05-03T05:04:03.837Z"
+        },
+        "positionsLib": {
+            "contractName": "Positions",
+            "contractAddress": "0xEaE9f6d807Fb465470845F0DE4c58D6E765Ae34d",
+            "constructorArguments": [],
+            "created": "2023-05-03T05:04:06.289Z"
+        },
+        "rangePoolManager": {
+            "contractName": "RangePoolManager",
+            "contractAddress": "0xa254ff03db8b7d59C3f537c41b2b1D9f4147cD85",
+            "constructorArguments": [],
+            "created": "2023-05-03T05:04:08.435Z"
+        },
+        "rangePoolFactory": {
+            "contractName": "RangePoolFactory",
+            "contractAddress": "0x1598DCe2D358F652E6625039C3c12e63b0444Bef",
+            "constructorArguments": [
+                "0xa254ff03db8b7d59C3f537c41b2b1D9f4147cD85"
+            ],
+            "created": "2023-05-03T05:04:10.702Z"
+        },
+        "rangePool": {
+            "contractName": "RangePool",
+            "contractAddress": "0x3B2EC00a3b33661dD118cE9666be9caCCcfAD887",
+            "constructorArguments": [
+                "0x189f7Ba3C382aF7a5Ff38010Cf96D29e6c5f1e12",
+                "0x9c0e3c8C7B1fD2FdE8e933A55864Da2A8696E3D8",
+                "10",
+                "500",
+                "177159557114295710296101716160"
+            ],
+            "created": "2023-05-03T05:04:17.717Z"
         }
     }
 }

--- a/subgraph/src/mappings/rangepoolfactory.ts
+++ b/subgraph/src/mappings/rangepoolfactory.ts
@@ -62,6 +62,7 @@ export function handleRangePoolCreated(event: RangePoolCreated): void {
         }
         token1.decimals = decimals
     }
+    //TODO: calculate tick at initial sqrt price
 
     pool.token0 = token0.id
     pool.token1 = token1.id

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -8,9 +8,9 @@ dataSources:
       name: RangePoolFactory
       network: arbitrum-goerli
       source:
-          address: '0x58d8235108E12E6B725A53B57CD0b00C5eDeE0da'
+          address: '0x1598DCe2D358F652E6625039C3c12e63b0444Bef'
           abi: RangePoolFactory
-          startBlock: 13800000
+          startBlock: 18640000
       mapping:
           kind: ethereum/events
           apiVersion: 0.0.6
@@ -37,9 +37,9 @@ dataSources:
       name: RangePoolManager
       network: arbitrum-goerli
       source:
-          address: '0x33A28c58Ab9C2fc5Bc0eF84CA1b28763A904c4DD'
+          address: '0xa254ff03db8b7d59C3f537c41b2b1D9f4147cD85'
           abi: RangePoolManager
-          startBlock: 13800000
+          startBlock: 18640000
       mapping:
           kind: ethereum/events
           apiVersion: 0.0.6

--- a/tasks/deploy/utils/mintPosition.ts
+++ b/tasks/deploy/utils/mintPosition.ts
@@ -36,9 +36,9 @@ export class MintPosition {
 
     await validateMint({
       signer: hre.props.alice,
-      recipient: hre.props.alice.address,
-      lower: '100',
-      upper: '200',
+      recipient: '0x73a18F0E04A4c7E49C6B25c8f6Bc17674C806b67',
+      lower: '-887270',
+      upper: '887270',
       amount0: token0Amount,
       amount1: token1Amount,
       fungible: false,

--- a/test/contracts/rangepool.ts
+++ b/test/contracts/rangepool.ts
@@ -29,7 +29,7 @@ describe('RangePool Tests', function () {
 
   ////////// DEBUG FLAGS //////////
   let debugMode           = false
-  let balanceCheck        = true
+  let balanceCheck        = false
 
   const liquidityAmount = BigNumber.from('49902591570441687020675')
   const liquidityAmount2 = BigNumber.from('50102591670431696268925')
@@ -37,13 +37,9 @@ describe('RangePool Tests', function () {
   const minTickIdx = BigNumber.from('-887272')
   const maxTickIdx = BigNumber.from('887272')
 
-  //every test should clear out all liquidity
-
   before(async function () {
     await gBefore()
     let currentBlock = await ethers.provider.getBlockNumber()
-    //TODO: maybe just have one view function that grabs all these
-    //TODO: map it to an interface
     const pool: PoolState = await hre.props.rangePool.poolState()
     const liquidity = pool.liquidity
     const feeGrowthGlobal0 = pool.feeGrowthGlobal0
@@ -69,7 +65,7 @@ describe('RangePool Tests', function () {
     await mintSigners20(hre.props.token1, tokenAmount.mul(10), [hre.props.alice, hre.props.bob])
   })
 
-  it('token1 - Should mint, swap, and burn 21', async function () {
+  it('token1 - Should mint, swap, and burn', async function () {
 
     await validateMint({
       signer: hre.props.alice,
@@ -135,7 +131,7 @@ describe('RangePool Tests', function () {
     }
   })
 
-  it('token0 - Should mint, swap, and burn 21', async function () {
+  it('token0 - Should mint, swap, and burn', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     const aliceLiquidity = BigNumber.from('55483175795606442088768')
 
@@ -188,7 +184,7 @@ describe('RangePool Tests', function () {
     }
   })
 
-  it('token0 - Should mint and burn fungible position 21', async function () {
+  it('token0 - Should mint and burn fungible position', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     await validateMint({
       signer: hre.props.alice,
@@ -273,9 +269,14 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('0'),
       revertMessage: '',
     })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
   })
 
-  it('token0 - Should add in-range fungible liquidity 21', async function () {
+  it('token0 - Should add in-range fungible liquidity', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     await validateMint({
       signer: hre.props.alice,
@@ -340,9 +341,14 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('100000000000000000000'),
       revertMessage: '',
     })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
   })
 
-  it('token1 - Should mint, swap, and burn 21', async function () {
+  it('token1 - Should mint, swap, and burn', async function () {
     const liquidityAmount2 = BigNumber.from('690841800621472456980')
 
     await validateMint({
@@ -391,9 +397,14 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('10000000000000000000'),
       revertMessage: '',
     })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
   })
 
-  it('token1 - Should mint, swap, and burn custom position while in range 21', async function () {
+  it('token1 - Should mint, swap, and burn custom position while in range', async function () {
     if (debugMode) await getTickAtPrice()
     const aliceLiquidity = BigNumber.from('1577889144107833733009')
     const aliceLiquidity2 = BigNumber.from('1590926220637829792707')
@@ -446,9 +457,14 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('20082623526365456124'),
       revertMessage: '',
     })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
   })
 
-  it('token0 - Should autocompound fungible position 21', async function () {
+  it('token0 - Should autocompound fungible position', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     const aliceLiquidity = BigNumber.from('3852877204305891777654')
     const aliceToken2 = BigNumber.from('7703654602399898969634')
@@ -518,9 +534,14 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('136483615696225509030'),
       revertMessage: '',
     })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
   })
 
-  it('token0 - Should autocompound fungible position and add liquidity 21', async function () {
+  it('token0 - Should autocompound fungible position and add liquidity', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     const aliceLiquidity = BigNumber.from('7705754408611783555308')
     const aliceLiquidity2 = BigNumber.from('3852877204305891777654')
@@ -614,9 +635,14 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('300013568033977842761'),
       revertMessage: '',
     })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
   })
 
-  it('token0 - Should mint position inside the other 21', async function () {
+  it('token0 - Should mint position inside the other', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
 
     await validateMint({
@@ -686,9 +712,14 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('45512710081139321979'),
       revertMessage: '',
     })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
   })
 
-  it('pool - Should mint position inside the other 21', async function () {
+  it('pool - Should mint position inside the other', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     const aliceLiquidity = BigNumber.from('7705754408611783555308')
     const bobLiquidity = BigNumber.from('12891478442546858467877')
@@ -771,5 +802,111 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('99375039384589972731'),
       revertMessage: '',
     })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
+  })
+
+  it('pool - Should mint position inside the other and not steal fee share :: KEBABSEC', async function () {
+    const pool: PoolState = await hre.props.rangePool.poolState()
+    const aliceLiquidity = BigNumber.from('3852877204305891777654')
+    const bobLiquidity = BigNumber.from('10356653617731432349576')
+
+    await validateSwap({
+      signer: hre.props.alice,
+      recipient: hre.props.alice.address,
+      zeroForOne: false,
+      amountIn: tokenAmount,
+      sqrtPriceLimitX96: maxPrice,
+      balanceInDecrease: BigNumber.from('0'), // token1 increase in pool
+      balanceOutIncrease: BigNumber.from('0'), // token0 decrease in pool
+      revertMessage: '',
+    })
+
+
+    await validateMint({
+      signer: hre.props.alice,
+      recipient: hre.props.alice.address,
+      lower: '500',
+      upper: '1000',
+      amount0: tokenAmount,
+      amount1: tokenAmount,
+      fungible: true,
+      balance0Decrease: BigNumber.from('0'),
+      balance1Decrease: tokenAmount,
+      tokenAmount: aliceLiquidity,
+      liquidityIncrease: aliceLiquidity,
+      revertMessage: '',
+      collectRevertMessage: ''
+    })
+
+    await validateSwap({
+      signer: hre.props.alice,
+      recipient: hre.props.alice.address,
+      zeroForOne: true,
+      amountIn: tokenAmount,
+      sqrtPriceLimitX96: minPrice,
+      balanceInDecrease: BigNumber.from('92774696514123048139'), // token1 increase in pool
+      balanceOutIncrease: BigNumber.from('99949999999999999999'), // token0 decrease in pool
+      revertMessage: '',
+    })
+
+    await validateMint({
+      signer: hre.props.bob,
+      recipient: hre.props.bob.address,
+      lower: '600',
+      upper: '800',
+      amount0: tokenAmount,
+      amount1: tokenAmount,
+      fungible: true,
+      balance0Decrease: tokenAmount,
+      balance1Decrease: BN_ZERO,
+      tokenAmount: bobLiquidity,
+      liquidityIncrease: bobLiquidity,
+      revertMessage: '',
+    })
+
+    await validateBurn({
+      signer: hre.props.bob,
+      lower: '600',
+      upper: '800',
+      tokenAmount: bobLiquidity.div(2),
+      liquidityAmount: bobLiquidity.div(2),
+      fungible: true,
+      balance0Increase: BigNumber.from('50000000000000000000'),
+      balance1Increase: BN_ZERO,
+      revertMessage: '',
+    })
+
+    await validateBurn({
+      signer: hre.props.bob,
+      lower: '600',
+      upper: '800',
+      tokenAmount: bobLiquidity.div(2),
+      liquidityAmount: bobLiquidity.div(2),
+      fungible: true,
+      balance0Increase: BigNumber.from('50000000000000000000'),
+      balance1Increase: BN_ZERO,
+      revertMessage: '',
+    })
+
+    await validateBurn({
+      signer: hre.props.alice,
+      lower: '500',
+      upper: '1000',
+      tokenAmount: aliceLiquidity,
+      liquidityAmount: aliceLiquidity,
+      fungible: true,
+      balance0Increase: BigNumber.from('92774696514123048139'),
+      balance1Increase: BigNumber.from('49999999999999999'),
+      revertMessage: '',
+    })
+
+    if (balanceCheck) {
+      console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
+      console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
+    }
   })
 })

--- a/test/contracts/rangepool.ts
+++ b/test/contracts/rangepool.ts
@@ -139,7 +139,7 @@ describe('RangePool Tests', function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     const aliceLiquidity = BigNumber.from('55483175795606442088768')
 
-    await getTickAtPrice()
+    if (debugMode) await getTickAtPrice()
 
     await validateMint({
       signer: hre.props.alice,
@@ -156,7 +156,7 @@ describe('RangePool Tests', function () {
       collectRevertMessage: ''
     })
 
-    await getTickAtPrice()
+    if (debugMode) await getTickAtPrice()
 
     await validateSwap({
       signer: hre.props.alice,
@@ -169,7 +169,7 @@ describe('RangePool Tests', function () {
       revertMessage: '',
     })
 
-    await getTickAtPrice()
+    if (debugMode) await getTickAtPrice()
 
     await validateBurn({
       signer: hre.props.alice,
@@ -178,7 +178,7 @@ describe('RangePool Tests', function () {
       liquidityAmount: aliceLiquidity,
       fungible: false,
       balance0Increase: BigNumber.from('110739133337787245412'),
-      balance1Increase: BigNumber.from('44408522634253079'),
+      balance1Increase: BigNumber.from('49999999999999999'),
       revertMessage: '',
     })
 
@@ -188,7 +188,7 @@ describe('RangePool Tests', function () {
     }
   })
 
-  it('token0 - Should mint and burn fungible position', async function () {
+  it('token0 - Should mint and burn fungible position 21', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     await validateMint({
       signer: hre.props.alice,
@@ -275,7 +275,7 @@ describe('RangePool Tests', function () {
     })
   })
 
-  it('token0 - Should add in-range fungible liquidity', async function () {
+  it('token0 - Should add in-range fungible liquidity 21', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
     await validateMint({
       signer: hre.props.alice,
@@ -327,6 +327,8 @@ describe('RangePool Tests', function () {
       revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 2236771031221735906744102008774832778161797975119947154210717982934819779160, 419027207938949970577)',
     })
 
+    if (debugMode) await getTickAtPrice()
+
     await validateBurn({
       signer: hre.props.alice,
       lower: '10000',
@@ -340,14 +342,14 @@ describe('RangePool Tests', function () {
     })
   })
 
-  it('token1 - Should mint, swap, and burn', async function () {
-    const liquidityAmount2 = BigNumber.from('50102591670431696268925')
+  it('token1 - Should mint, swap, and burn 21', async function () {
+    const liquidityAmount2 = BigNumber.from('690841800621472456980')
 
     await validateMint({
       signer: hre.props.alice,
       recipient: hre.props.alice.address,
-      lower: '20',
-      upper: '60',
+      lower: '20000',
+      upper: '30000',
       amount0: tokenAmount,
       amount1: tokenAmount,
       fungible: false,
@@ -364,46 +366,48 @@ describe('RangePool Tests', function () {
       amountIn: tokenAmount.div(10),
       sqrtPriceLimitX96: maxPrice,
       balanceInDecrease: BigNumber.from('10000000000000000000'),
-      balanceOutIncrease: BigNumber.from('9973042439282787765'),
+      balanceOutIncrease: BigNumber.from('1345645380966504669'),
       revertMessage: '',
     })
 
     await validateBurn({
       signer: hre.props.alice,
-      lower: '20',
-      upper: '40',
+      lower: '20000',
+      upper: '30000',
       liquidityAmount: liquidityAmount2,
-      fungible: false,
+      fungible: true,
       balance0Increase: BN_ZERO,
       balance1Increase: tokenAmount.sub(1),
-      revertMessage: 'NotEnoughPositionLiquidity()',
+      revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 46917584274566950978499300549752982364206881961648429939058743511297364061881, 690841800621472456980)',
     })
 
     await validateBurn({
       signer: hre.props.alice,
-      lower: '20',
-      upper: '60',
+      lower: '20000',
+      upper: '30000',
       liquidityAmount: liquidityAmount2,
       fungible: false,
-      balance0Increase: BigNumber.from('90026957560717212234'),
+      balance0Increase: BigNumber.from('98654354619033495330'),
       balance1Increase: BigNumber.from('10000000000000000000'),
       revertMessage: '',
     })
   })
 
-  it('token1 - Should mint, swap, and burn custom position while in range', async function () {
-
+  it('token1 - Should mint, swap, and burn custom position while in range 21', async function () {
+    if (debugMode) await getTickAtPrice()
+    const aliceLiquidity = BigNumber.from('1577889144107833733009')
+    const aliceLiquidity2 = BigNumber.from('1590926220637829792707')
     await validateMint({
       signer: hre.props.alice,
       recipient: hre.props.alice.address,
-      lower: '20',
-      upper: '60',
+      lower: '25000',
+      upper: '30000',
       amount0: tokenAmount,
       amount1: tokenAmount,
       fungible: false,
       balance0Decrease: tokenAmount,
       balance1Decrease: BN_ZERO,
-      liquidityIncrease: liquidityAmount2,
+      liquidityIncrease: aliceLiquidity,
       revertMessage: '',
     })
 
@@ -414,39 +418,41 @@ describe('RangePool Tests', function () {
       amountIn: tokenAmount.div(10),
       sqrtPriceLimitX96: maxPrice,
       balanceInDecrease: BigNumber.from('10000000000000000000'),
-      balanceOutIncrease: BigNumber.from('9973042439282787765'),
+      balanceOutIncrease: BigNumber.from('819054826219841040'),
       revertMessage: '',
     })
 
     await validateMint({
       signer: hre.props.alice,
       recipient: hre.props.alice.address,
-      lower: '20',
-      upper: '60',
+      lower: '25000',
+      upper: '30000',
       amount0: tokenAmount,
       amount1: tokenAmount,
       fungible: false,
       balance0Decrease: BigNumber.from('100000000000000000000'),
-      balance1Decrease: BigNumber.from('11108399606927461884'),
-      liquidityIncrease: BigNumber.from('55655960961787058072954'),
+      balance1Decrease: BigNumber.from('10082623526365456124'),
+      liquidityIncrease: aliceLiquidity2,
       revertMessage: '',
     })
 
     await validateBurn({
       signer: hre.props.alice,
-      lower: '20',
-      upper: '60',
-      liquidityAmount: liquidityAmount2.add(BigNumber.from('55655960961787058072954')),
+      lower: '25000',
+      upper: '30000',
+      liquidityAmount: aliceLiquidity.add(aliceLiquidity2),
       fungible: false,
-      balance0Increase: BigNumber.from('190021968544989707088'),
-      balance1Increase: BigNumber.from('21108399606927461884'),
+      balance0Increase: BigNumber.from('199180535441500909414'),
+      balance1Increase: BigNumber.from('20082623526365456124'),
       revertMessage: '',
     })
   })
 
-  it('token0 - Should autocompound fungible position', async function () {
+  it('token0 - Should autocompound fungible position 21', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
-
+    const aliceLiquidity = BigNumber.from('3852877204305891777654')
+    const aliceToken2 = BigNumber.from('7703654602399898969634')
+    const aliceLiquidity2 = BigNumber.from('7705754408611783555308')
     await validateMint({
       signer: hre.props.alice,
       recipient: hre.props.alice.address,
@@ -455,21 +461,21 @@ describe('RangePool Tests', function () {
       amount0: tokenAmount,
       amount1: tokenAmount,
       fungible: true,
-      balance0Decrease: BigNumber.from('100000000000000000000'),
-      balance1Decrease: BigNumber.from('0'),
-      tokenAmount: BigNumber.from('4152939701311089823384'),
-      liquidityIncrease: BigNumber.from('4152939701311089823384'),
+      balance0Decrease: BN_ZERO,
+      balance1Decrease: tokenAmount,
+      tokenAmount: aliceLiquidity,
+      liquidityIncrease: aliceLiquidity,
       revertMessage: '',
     })
 
     await validateSwap({
       signer: hre.props.alice,
       recipient: hre.props.alice.address,
-      zeroForOne: false,
+      zeroForOne: true,
       amountIn: tokenAmount.div(2),
-      sqrtPriceLimitX96: maxPrice,
+      sqrtPriceLimitX96: minPrice,
       balanceInDecrease: BigNumber.from('50000000000000000000'),
-      balanceOutIncrease: BigNumber.from('46986079114717368335'),
+      balanceOutIncrease: BigNumber.from('54487289918860678020'),
       revertMessage: '',
     })
 
@@ -482,9 +488,9 @@ describe('RangePool Tests', function () {
       amount1: tokenAmount,
       fungible: true,
       balance0Decrease: BigNumber.from('100000000000000000000'),
-      balance1Decrease: BigNumber.from('94356685012507865298'),
-      tokenAmount: BigNumber.from('7835310791950434814745'),
-      liquidityIncrease: BigNumber.from('7837152465450979996912'),
+      balance1Decrease: BigNumber.from('90970905615086187051'),
+      tokenAmount: aliceToken2,
+      liquidityIncrease: BigNumber.from('7705754408611783555308'),
       revertMessage: '',
       collectRevertMessage: ''
     })
@@ -496,7 +502,7 @@ describe('RangePool Tests', function () {
       tokenAmount: BigNumber.from('11988250493261524638130'),
       liquidityAmount: BigNumber.from('11986657697951620560434'),
       fungible: true,
-      balance0Increase: BigNumber.from('153013648220322291925'),
+      balance0Increase: BigNumber.from('150000000000000000000'),
       balance1Increase: BigNumber.from('144243177493286617045'),
       revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 2381093050879867228278279701469820094323623974324911225843268442440969283554, 11988250493261524638130)',
     })
@@ -505,17 +511,20 @@ describe('RangePool Tests', function () {
       signer: hre.props.alice,
       lower: '500',
       upper: '1000',
-      tokenAmount: BigNumber.from('11988250493261524638129'),
-      liquidityAmount: BigNumber.from('11990092166762069820296'),
+      tokenAmount: aliceLiquidity.add(aliceToken2),
+      liquidityAmount: aliceLiquidity.add(aliceLiquidity2),
       fungible: true,
-      balance0Increase: BigNumber.from('153013920885282631664'),
-      balance1Increase: BigNumber.from('144356685012507865298'),
+      balance0Increase: BigNumber.from('150000000000000000000'),
+      balance1Increase: BigNumber.from('136483615696225509030'),
       revertMessage: '',
     })
   })
 
-  it('token0 - Should autocompound fungible position and add liquidity', async function () {
+  it('token0 - Should autocompound fungible position and add liquidity 21', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
+    const aliceLiquidity = BigNumber.from('7705754408611783555308')
+    const aliceLiquidity2 = BigNumber.from('3852877204305891777654')
+    const aliceToken2 = BigNumber.from('3851318661512648798121')
 
     await validateMint({
       signer: hre.props.alice,
@@ -526,9 +535,9 @@ describe('RangePool Tests', function () {
       amount1: tokenAmount,
       fungible: true,
       balance0Decrease: BigNumber.from('100000000000000000000'),
-      balance1Decrease: BigNumber.from('0'),
-      tokenAmount: BigNumber.from('4152939701311089823384'),
-      liquidityIncrease: BigNumber.from('4152939701311089823384'),
+      balance1Decrease: BigNumber.from('90970905615086187051'),
+      tokenAmount: aliceLiquidity,
+      liquidityIncrease: aliceLiquidity,
       revertMessage: '',
       collectRevertMessage: ''
     })
@@ -540,7 +549,7 @@ describe('RangePool Tests', function () {
       amountIn: tokenAmount.div(2),
       sqrtPriceLimitX96: maxPrice,
       balanceInDecrease: BigNumber.from('50000000000000000000'), // token1 increase in pool
-      balanceOutIncrease: BigNumber.from('46986079114717368335'), // token0 decrease in pool
+      balanceOutIncrease: BigNumber.from('46172841786879071879'), // token0 decrease in pool
       revertMessage: '',
     })
 
@@ -551,7 +560,7 @@ describe('RangePool Tests', function () {
       amountIn: tokenAmount.div(4),
       sqrtPriceLimitX96: minPrice,
       balanceInDecrease: BigNumber.from('25000000000000000000'),
-      balanceOutIncrease: BigNumber.from('26722233818729405092'),
+      balanceOutIncrease: BigNumber.from('27122499921707680271'),
       revertMessage: '',
     })
 
@@ -561,8 +570,8 @@ describe('RangePool Tests', function () {
       zeroForOne: false,
       amountIn: tokenAmount.mul(2),
       sqrtPriceLimitX96: maxPrice,
-      balanceInDecrease: BigNumber.from('84523612529148614720'),
-      balanceOutIncrease: BigNumber.from('77990416093329296312'),
+      balanceInDecrease: BigNumber.from('86165162340599335983'),
+      balanceOutIncrease: BigNumber.from('78764658213120928119'),
       revertMessage: '',
     })
 
@@ -576,8 +585,8 @@ describe('RangePool Tests', function () {
       fungible: true,
       balance0Decrease: BigNumber.from('0'),
       balance1Decrease: BigNumber.from('100000000000000000000'),
-      tokenAmount: BigNumber.from('3851494258715939638949'),
-      liquidityIncrease: BigNumber.from('3852877204305891777654'),
+      tokenAmount: aliceToken2,
+      liquidityIncrease: aliceLiquidity2,
       revertMessage: '',
       collectRevertMessage: ''
     })
@@ -586,28 +595,28 @@ describe('RangePool Tests', function () {
       signer: hre.props.alice,
       lower: '500',
       upper: '1000',
-      tokenAmount: BigNumber.from('8004433960027029462334'),
+      tokenAmount: aliceLiquidity.add(aliceToken2).add(1),
       liquidityAmount: BigNumber.from('11986657697951620560434'),
       fungible: true,
       balance0Increase: BigNumber.from('153013648220322291925'),
       balance1Increase: BigNumber.from('144243177493286617045'),
-      revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 2381093050879867228278279701469820094323623974324911225843268442440969283554, 8004433960027029462334)',
+      revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 2381093050879867228278279701469820094323623974324911225843268442440969283554, 11557073070124432353430)'
     })
 
     await validateBurn({
       signer: hre.props.alice,
       lower: '500',
       upper: '1000',
-      tokenAmount: BigNumber.from('8004433960027029462333'),
-      liquidityAmount: BigNumber.from('8006331950567098231863'),
+      tokenAmount: aliceLiquidity.add(aliceToken2),
+      liquidityAmount: BigNumber.from('11559154372605880114611'), //TODO: investigate
       fungible: true,
-      balance0Increase: BigNumber.from('23504791953335351'),
-      balance1Increase: BigNumber.from('207801378710419209627'),
+      balance0Increase: BigNumber.from('62500000000000000'),
+      balance1Increase: BigNumber.from('300013568033977842761'),
       revertMessage: '',
     })
   })
 
-  it('token0 - Should mint position inside the other', async function () {
+  it('token0 - Should mint position inside the other 21', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
 
     await validateMint({
@@ -637,7 +646,7 @@ describe('RangePool Tests', function () {
       revertMessage: '',
     })
 
-    await getTickAtPrice()
+    if (debugMode) await getTickAtPrice()
 
     await validateMint({
       signer: hre.props.bob,
@@ -679,8 +688,11 @@ describe('RangePool Tests', function () {
     })
   })
 
-  it('pool - Should mint position inside the other', async function () {
+  it('pool - Should mint position inside the other 21', async function () {
     const pool: PoolState = await hre.props.rangePool.poolState()
+    const aliceLiquidity = BigNumber.from('7705754408611783555308')
+    const bobLiquidity = BigNumber.from('12891478442546858467877')
+    const bobLiquidity2 = BigNumber.from('4901161634764542438934')
 
     await validateMint({
       signer: hre.props.alice,
@@ -691,9 +703,9 @@ describe('RangePool Tests', function () {
       amount1: tokenAmount,
       fungible: true,
       balance0Decrease: BigNumber.from('100000000000000000000'),
-      balance1Decrease: BigNumber.from('0'),
-      tokenAmount: BigNumber.from('4152939701311089823384'),
-      liquidityIncrease: BigNumber.from('4152939701311089823384'),
+      balance1Decrease: BigNumber.from('90970905615086187051'),
+      tokenAmount: aliceLiquidity,
+      liquidityIncrease: aliceLiquidity,
       revertMessage: '',
       collectRevertMessage: ''
     })
@@ -704,8 +716,8 @@ describe('RangePool Tests', function () {
       zeroForOne: false,
       amountIn: tokenAmount,
       sqrtPriceLimitX96: BigNumber.from('82255474610179467046984074964'),
-      balanceInDecrease: BigNumber.from('53557189146645258776'), // token1 increase in pool
-      balanceOutIncrease: BigNumber.from('50287324067551161127'), // token0 decrease in pool
+      balanceInDecrease: BigNumber.from('8404133769503785680'), // token1 increase in pool
+      balanceOutIncrease: BigNumber.from('7801206245756322179'), // token0 decrease in pool
       revertMessage: '',
     })
 
@@ -719,8 +731,8 @@ describe('RangePool Tests', function () {
       fungible: true,
       balance0Decrease: BigNumber.from('31002239349424966834'),
       balance1Decrease: BigNumber.from('100000000000000000000'),
-      tokenAmount: BigNumber.from('12891478442546858467877'),
-      liquidityIncrease: BigNumber.from('12891478442546858467877'),
+      tokenAmount: bobLiquidity,
+      liquidityIncrease: bobLiquidity,
       revertMessage: '',
     })
 
@@ -728,8 +740,8 @@ describe('RangePool Tests', function () {
       signer: hre.props.bob,
       lower: '600',
       upper: '800',
-      tokenAmount: BigNumber.from('4901161634764542438934'),
-      liquidityAmount: BigNumber.from('4901161634764542438934'),
+      tokenAmount: bobLiquidity2,
+      liquidityAmount: bobLiquidity2,
       fungible: true,
       balance0Increase: BigNumber.from('11786622206938309592'),
       balance1Increase: BigNumber.from('38018615604156121197'),
@@ -740,8 +752,8 @@ describe('RangePool Tests', function () {
       signer: hre.props.bob,
       lower: '600',
       upper: '800',
-      tokenAmount: BigNumber.from('7990316807782316028943'),
-      liquidityAmount: BigNumber.from('7990316807782316028943'),
+      tokenAmount: bobLiquidity.sub(bobLiquidity2),
+      liquidityAmount: bobLiquidity.sub(bobLiquidity2),
       fungible: true,
       balance0Increase: BigNumber.from('19215617142486657242'),
       balance1Increase: BigNumber.from('61981384395843878804'),
@@ -752,11 +764,11 @@ describe('RangePool Tests', function () {
       signer: hre.props.alice,
       lower: '500',
       upper: '1000',
-      tokenAmount: BigNumber.from('4152939701311089823384'),
-      liquidityAmount: BigNumber.from('4152939701311089823384'),
+      tokenAmount: aliceLiquidity,
+      liquidityAmount: aliceLiquidity,
       fungible: true,
-      balance0Increase: BigNumber.from('49712675932448838872'),
-      balance1Increase: BigNumber.from('53557189146645258776'),
+      balance0Increase: BigNumber.from('92198793754243677820'),
+      balance1Increase: BigNumber.from('99375039384589972731'),
       revertMessage: '',
     })
   })

--- a/test/contracts/rangepoolfactory.ts
+++ b/test/contracts/rangepoolfactory.ts
@@ -39,7 +39,7 @@ describe('RangePoolFactory Tests', function () {
           '500',
           '177159557114295710296101716160'
         )
-    ).to.be.revertedWith('IdenticalTokenAddresses()')
+    ).to.be.revertedWith('InvalidTokenAddress()')
   })
 
   it('Should not create pool if the pair already exists', async function () {
@@ -64,7 +64,7 @@ describe('RangePoolFactory Tests', function () {
       hre.props.rangePoolFactory
         .connect(hre.props.admin)
         .createRangePool(hre.props.token1.address, hre.props.token0.address, '1000', '177159557114295710296101716160')
-    ).to.be.revertedWith('InvalidTokenDecimals()')
+    ).to.be.revertedWith('InvalidTokenAddress()')
     await hre.props.token0.connect(hre.props.admin).setDecimals(18)
   })
 
@@ -74,7 +74,7 @@ describe('RangePoolFactory Tests', function () {
       hre.props.rangePoolFactory
         .connect(hre.props.admin)
         .createRangePool(hre.props.token1.address, hre.props.token0.address, '1000', '177159557114295710296101716160')
-    ).to.be.revertedWith('InvalidTokenDecimals()')
+    ).to.be.revertedWith('InvalidTokenAddress()')
     await hre.props.token1.connect(hre.props.admin).setDecimals(18)
   })
 

--- a/test/utils/contracts/rangepool.ts
+++ b/test/utils/contracts/rangepool.ts
@@ -141,8 +141,6 @@ export async function validateSwap(params: ValidateSwapParams) {
   const poolState: PoolState = quote[0]
   const swapCache: SwapCache = quote[1]
 
-  console.log('transferring in:', amountIn.toString())
-
   if (revertMessage == '') {
     let txn = await hre.props.rangePool
       .connect(signer)
@@ -321,8 +319,6 @@ export async function validateMint(params: ValidateMintParams) {
   expect(upperTickAfter.liquidityDelta.sub(upperTickBefore.liquidityDelta)).to.be.equal(
     BN_ZERO.sub(liquidityIncrease)
   )
-  // console.log('position liquidity after:', positionAfter.liquidity)
-  // console.log('tick after', )
   expect(positionAfter.liquidity.sub(positionBefore.liquidity)).to.be.equal(liquidityIncrease)
 }
 

--- a/test/utils/contracts/rangepool.ts
+++ b/test/utils/contracts/rangepool.ts
@@ -138,8 +138,9 @@ export async function validateSwap(params: ValidateSwapParams) {
 
   // quote pre-swap and validate balance changes match post-swap
   const quote = await hre.props.rangePool.quote(zeroForOne, amountIn, sqrtPriceLimitX96)
-  const poolState: PoolState = quote[0]
-  const swapCache: SwapCache = quote[1]
+  const inAmount = quote[0]
+  const outAmount = quote[1]
+  const priceAfterQuote = quote[2]
 
   if (revertMessage == '') {
     let txn = await hre.props.rangePool
@@ -167,13 +168,15 @@ export async function validateSwap(params: ValidateSwapParams) {
 
   expect(balanceInBefore.sub(balanceInAfter)).to.be.equal(balanceInDecrease)
   expect(balanceOutAfter.sub(balanceOutBefore)).to.be.equal(balanceOutIncrease)
-  expect(balanceInBefore.sub(balanceInAfter)).to.be.equal(swapCache.input)
-  expect(balanceOutAfter.sub(balanceOutBefore)).to.be.equal(swapCache.output)
+  expect(balanceInBefore.sub(balanceInAfter)).to.be.equal(inAmount)
+  expect(balanceOutAfter.sub(balanceOutBefore)).to.be.equal(outAmount)
 
   const poolAfter: PoolState = await hre.props.rangePool.poolState()
   const liquidityAfter = poolAfter.liquidity
-  //TODO: check feeGrowth before and after swap
   const priceAfter = poolAfter.price
+
+  expect(priceAfter).to.be.equal(priceAfterQuote)
+  //TODO: check feeGrowth before and after swap
 
   // expect(liquidityAfter).to.be.equal(finalLiquidity);
   // expect(priceAfter).to.be.equal(finalPrice);

--- a/test/utils/setup/initialSetup.ts
+++ b/test/utils/setup/initialSetup.ts
@@ -297,7 +297,7 @@ export class InitialSetup {
       .createRangePool(
         hre.props.token0.address,
         hre.props.token1.address,
-        '3000',
+        '500',
         '177159557114295710296101716160'
     )
     hre.nonce += 1


### PR DESCRIPTION
This PR fixes the early return on minting positions where it would always set `position.feeGrowthInsideLast` to `0`.

After calling `Ticks.insert()`, `position.feeGrowthInsideLast` is updated again to ensure there is no double discounting of fee growth occuring inside the range.

`Ticks._cross` also saw some updates as we are now tracking `tickAtPrice` within `poolState` for proper oracle updates and tick initialization.