### PR TITLE
Fee Tier Tick Spacing Check; Refund Recipient

### DIFF
--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -196,6 +196,7 @@ contract RangePool is
 
     function swap(
         address recipient,
+        address refundRecipient,
         bool zeroForOne,
         uint256 amountIn,
         uint160 priceLimit
@@ -220,15 +221,14 @@ contract RangePool is
             pool
         );
 
-        // handle fee return and transfer out
         if (zeroForOne) {
             if (cache.input > 0) {
-                _transferOut(recipient, token0, cache.input);
+                _transferOut(refundRecipient, token0, cache.input);
             }
             _transferOut(recipient, token1, cache.output);
         } else {
             if (cache.input > 0) {
-                _transferOut(recipient, token1, cache.input);
+                _transferOut(refundRecipient, token1, cache.input);
             }
             _transferOut(recipient, token0, cache.output);
         }

--- a/contracts/interfaces/IRangePool.sol
+++ b/contracts/interfaces/IRangePool.sol
@@ -11,6 +11,7 @@ interface IRangePool is IRangePoolStructs {
 
     function swap(
         address recipient,
+        address refundRecipient,
         bool zeroForOne,
         uint256 amountIn,
         uint160 priceLimit

--- a/contracts/interfaces/IRangePoolStructs.sol
+++ b/contracts/interfaces/IRangePoolStructs.sol
@@ -69,7 +69,6 @@ interface IRangePoolStructs {
         int24  tickSpacing;
     }
 
-    //TODO: take out fungible option
     struct MintParams {
         address to;
         int24 lower;

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -201,7 +201,7 @@ library Ticks {
         uint160 priceLimit,
         IRangePoolStructs.PoolState memory pool,
         IRangePoolStructs.SwapCache memory cache
-    ) internal view returns (
+    ) internal pure returns (
             IRangePoolStructs.PoolState memory,
             IRangePoolStructs.SwapCache memory
     ) {

--- a/contracts/utils/RangePoolManager.sol
+++ b/contracts/utils/RangePoolManager.sol
@@ -25,6 +25,7 @@ contract RangePoolManager is
     error FeeToOnly();
     error FeeTierAlreadyEnabled();
     error TransferredToZeroAddress();
+    error FeeTierTickSpacingInvalid();
     
     constructor() {
         _owner = msg.sender;
@@ -127,6 +128,7 @@ contract RangePoolManager is
         if (feeTiers[swapFee] != 0) {
             revert FeeTierAlreadyEnabled();
         }
+        if(tickSpacing <= 0 || tickSpacing >= 16384) revert FeeTierTickSpacingInvalid();
         feeTiers[swapFee] = tickSpacing;
         emit FeeTierEnabled(swapFee, tickSpacing);
     }

--- a/test/utils/contracts/rangepool.ts
+++ b/test/utils/contracts/rangepool.ts
@@ -145,13 +145,13 @@ export async function validateSwap(params: ValidateSwapParams) {
   if (revertMessage == '') {
     let txn = await hre.props.rangePool
       .connect(signer)
-      .swap(signer.address, zeroForOne, amountIn, sqrtPriceLimitX96)
+      .swap(signer.address, signer.address, zeroForOne, amountIn, sqrtPriceLimitX96)
     await txn.wait()
   } else {
     await expect(
       hre.props.rangePool
         .connect(signer)
-        .swap(signer.address, zeroForOne, amountIn, sqrtPriceLimitX96)
+        .swap(signer.address, signer.address, zeroForOne, amountIn, sqrtPriceLimitX96)
     ).to.be.revertedWith(revertMessage)
     return
   }


### PR DESCRIPTION
This PR remediates the following:
https://hackmd.io/@psdoc/r1VSEC2l3#Medium-Unused-token-refunds-are-always-made-to-the-recipient
https://hackmd.io/@psdoc/r1VSEC2l3#Low-Lack-of-Input-Sanitization-for-tickSpacing