### PR TITLE
Handle Overflow on Tick Index

### DIFF
--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -196,6 +196,7 @@ contract RangePool is
 
     function swap(
         address recipient,
+        address refundRecipient,
         bool zeroForOne,
         uint256 amountIn,
         uint160 priceLimit
@@ -220,15 +221,14 @@ contract RangePool is
             pool
         );
 
-        // handle fee return and transfer out
         if (zeroForOne) {
             if (cache.input > 0) {
-                _transferOut(recipient, token0, cache.input);
+                _transferOut(refundRecipient, token0, cache.input);
             }
             _transferOut(recipient, token1, cache.output);
         } else {
             if (cache.input > 0) {
-                _transferOut(recipient, token1, cache.input);
+                _transferOut(refundRecipient, token1, cache.input);
             }
             _transferOut(recipient, token0, cache.output);
         }

--- a/contracts/interfaces/IRangePool.sol
+++ b/contracts/interfaces/IRangePool.sol
@@ -11,6 +11,7 @@ interface IRangePool is IRangePoolStructs {
 
     function swap(
         address recipient,
+        address refundRecipient,
         bool zeroForOne,
         uint256 amountIn,
         uint160 priceLimit

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import './TickMath.sol';
 import '../interfaces/IRangePoolStructs.sol';
+import 'hardhat/console.sol';
 
 library TickMap {
 
@@ -91,7 +92,6 @@ library TickMap {
                 uint256 block_ = tickMap.words[blockIndex] & ((1 << (wordIndex & 0xFF)) - 1);
                 if (block_ == 0) {
                     uint256 blockMap = tickMap.blocks & ((1 << blockIndex) - 1);
-                    // assert(blockMap != 0);
                     if (blockMap == 0) return tick;
 
                     blockIndex = _msb(blockMap);
@@ -116,14 +116,18 @@ library TickMap {
               uint256 wordIndex,
               uint256 blockIndex
             ) = getIndices(tick);
-            uint256 word = tickMap.ticks[wordIndex] & ~((1 << ((tickIndex & 0xFF) + 1)) - 1);
+            uint256 word;
+            if ((tickIndex & 0xFF) != 255) {
+                word = tickMap.ticks[wordIndex] & ~((1 << ((tickIndex & 0xFF) + 1)) - 1);
+            }
             if (word == 0) {
-                uint256 block_ = tickMap.words[blockIndex] & ~((1 << ((wordIndex & 0xFF) + 1)) - 1);
+                uint256 block_;
+                if ((blockIndex & 0xFF) != 255) {
+                    block_ = tickMap.words[blockIndex] & ~((1 << ((wordIndex & 0xFF) + 1)) - 1);
+                }
                 if (block_ == 0) {
                     uint256 blockMap = tickMap.blocks & ~((1 << blockIndex + 1) - 1);
-                    // assert(blockMap != 0);
-                    //if blockMap == 0 return type(int24).max()
-
+                    if (blockMap == 0) return tick;
                     blockIndex = _lsb(blockMap);
                     block_ = tickMap.words[blockIndex];
                 }

--- a/test/utils/contracts/rangepool.ts
+++ b/test/utils/contracts/rangepool.ts
@@ -145,13 +145,13 @@ export async function validateSwap(params: ValidateSwapParams) {
   if (revertMessage == '') {
     let txn = await hre.props.rangePool
       .connect(signer)
-      .swap(signer.address, zeroForOne, amountIn, sqrtPriceLimitX96)
+      .swap(signer.address, signer.address, zeroForOne, amountIn, sqrtPriceLimitX96)
     await txn.wait()
   } else {
     await expect(
       hre.props.rangePool
         .connect(signer)
-        .swap(signer.address, zeroForOne, amountIn, sqrtPriceLimitX96)
+        .swap(signer.address, signer.address, zeroForOne, amountIn, sqrtPriceLimitX96)
     ).to.be.revertedWith(revertMessage)
     return
   }


### PR DESCRIPTION
This PR addresses the following issue:

In `TickMap.sol`:
`uint256 word = tickMap.ticks[wordIndex] & ~((1 << ((tickIndex & 0xFF) + 1)) - 1);`

(tickIndex & 0xFF) is the same as tickIndex % 256. Thus overflow in the case of tickIndex & 0xFF == 255 is possible.

We thus set word = 0 if tickIndex % 256 = 255.