### PR TITLE
Switch to `require()` statements for testnet

### DIFF
--- a/contracts/libraries/DyDxMath.sol
+++ b/contracts/libraries/DyDxMath.sol
@@ -115,8 +115,8 @@ library DyDxMath {
             dx = _getDx(liquidityAmount, currentPrice, priceUpper, roundUp);
             dy = _getDy(liquidityAmount, priceLower, currentPrice, roundUp);
         }
-        if (dx > uint128(type(int128).max)) revert AmountsOutOfBounds();
-        if (dy > uint128(type(int128).max)) revert AmountsOutOfBounds();
+        if (dx > uint128(type(int128).max)) require(false, 'AmountsOutOfBounds()');
+        if (dy > uint128(type(int128).max)) require(false, 'AmountsOutOfBounds()');
         return (uint128(dx), uint128(dy));
     }
 }

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -90,7 +90,7 @@ library Positions {
             params.amount1,
             params.amount0
         );
-        if (liquidityMinted == 0) revert NoLiquidityBeingAdded();
+        if (liquidityMinted == 0) require(false, 'NoLiquidityBeingAdded()');
         (params.amount0, params.amount1) = DyDxMath.getAmountsForLiquidity(
             priceLower,
             priceUpper,
@@ -98,7 +98,7 @@ library Positions {
             liquidityMinted,
             true
         );
-        if (liquidityMinted > uint128(type(int128).max)) revert LiquidityOverflow();
+        if (liquidityMinted > uint128(type(int128).max)) require(false, 'LiquidityOverflow()');
 
         return (params, liquidityMinted);
     }
@@ -228,7 +228,7 @@ library Positions {
             );
             return (state, position, removeParams.amount0, removeParams.amount1);
         } 
-        if (params.amount > position.liquidity) revert NotEnoughPositionLiquidity();
+        if (params.amount > position.liquidity) require(false, 'NotEnoughPositionLiquidity()');
         {
             uint128 amount0Removed; uint128 amount1Removed;
             (amount0Removed, amount1Removed) = DyDxMath.getAmountsForLiquidity(

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -82,7 +82,7 @@ library Samples {
     ) external returns (
         IRangePoolStructs.PoolState memory
     ) {
-        if (state.samples.length == 0) revert SampleArrayUninitialized();
+        if (state.samples.length == 0) require(false, 'SampleArrayUninitialized()');
         for (uint16 i = state.samples.lengthNext; i < sampleLengthNext; i++) {
             samples[i].tickSecondsAccum = 1;
         }
@@ -98,7 +98,7 @@ library Samples {
         int56[]   memory tickSecondsAccum,
         uint160[] memory secondsPerLiquidityAccum
     ) {
-        if (params.sampleLength == 0) revert InvalidSampleLength();
+        if (params.sampleLength == 0) require(false, 'InvalidSampleLength()');
 
         tickSecondsAccum = new int56[](params.secondsAgos.length);
         secondsPerLiquidityAccum = new uint160[](params.secondsAgos.length);
@@ -299,7 +299,7 @@ library Samples {
         if (firstSample.blockTimestamp == 0) {
             firstSample = _poolSample(pool, 0);
         }
-        if(!_lte(firstSample.blockTimestamp, targetTime)) revert SampleLengthNotAvailable();
+        if(!_lte(firstSample.blockTimestamp, targetTime)) require(false, 'SampleLengthNotAvailable()');
 
         return _binarySearch(
             pool,

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -147,12 +147,12 @@ library TickMap {
         )
     {
         unchecked {
-            if (tick > TickMath.MAX_TICK) revert TickIndexOverflow();
-            if (tick < TickMath.MIN_TICK) revert TickIndexUnderflow();
+            if (tick > TickMath.MAX_TICK) require(false, ' TickIndexOverflow()');
+            if (tick < TickMath.MIN_TICK) require(false, 'TickIndexUnderflow()');
             tickIndex = uint256(int256((tick - TickMath.MIN_TICK)));
             wordIndex = tickIndex >> 8;   // 2^8 ticks per word
             blockIndex = tickIndex >> 16; // 2^8 words per block
-            if (blockIndex > 255) revert BlockIndexOverflow();
+            if (blockIndex > 255) require(false, 'BlockIndexOverflow()');
         }
     }
 
@@ -162,7 +162,7 @@ library TickMap {
         int24 tick
     ) {
         unchecked {
-            if (tickIndex > uint24(TickMath.MAX_TICK * 2)) revert TickIndexOverflow();
+            if (tickIndex > uint24(TickMath.MAX_TICK * 2)) require(false, 'TickIndexOverflow()');
             tick = int24(int256(tickIndex) + TickMath.MIN_TICK);
         }
     }

--- a/contracts/libraries/TickMath.sol
+++ b/contracts/libraries/TickMath.sol
@@ -15,7 +15,6 @@ library TickMath {
 
     error TickOutOfBounds();
     error PriceOutOfBounds();
-    error WaitUntilEnoughObservations();
 
     function getSqrtRatioAtTick(int24 tick) external pure returns (uint160 getSqrtPriceX96) {
         return _getSqrtRatioAtTick(tick);
@@ -32,7 +31,8 @@ library TickMath {
     /// at the given tick.
     function _getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
         uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
-        if (absTick > uint256(uint24(MAX_TICK))) revert TickOutOfBounds();
+        if (absTick > uint256(uint24(MAX_TICK))) require(false, 'TickOutOfBounds()');
+        
         unchecked {
             uint256 ratio = absTick & 0x1 != 0
                 ? 0xfffcb933bd6fad37aa2d162d1a594001
@@ -67,7 +67,7 @@ library TickMath {
 
     function validatePrice(uint160 price) external pure {
         if (price < MIN_SQRT_RATIO || price >= MAX_SQRT_RATIO) {
-            revert PriceOutOfBounds();
+            require(false, 'PriceOutOfBounds()');
         }
     }
 
@@ -79,7 +79,7 @@ library TickMath {
     function _getTickAtSqrtRatio(uint160 sqrtPriceX96) internal pure returns (int24 tick) {
         // Second inequality must be < because the price can never reach the price at the max tick.
         if (sqrtPriceX96 < MIN_SQRT_RATIO || sqrtPriceX96 >= MAX_SQRT_RATIO)
-            revert PriceOutOfBounds();
+            require(false, 'PriceOutOfBounds()');
         uint256 ratio = uint256(sqrtPriceX96) << 32;
 
         uint256 r = ratio;

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -58,11 +58,11 @@ library Ticks {
         int24 upper,
         int24 tickSpacing
     ) public pure {
-        if (lower % tickSpacing != 0) revert InvalidLowerTick();
-        if (lower <= TickMath.MIN_TICK) revert InvalidLowerTick();
-        if (upper % tickSpacing != 0) revert InvalidUpperTick();
-        if (upper >= TickMath.MAX_TICK) revert InvalidUpperTick();
-        if (lower >= upper) revert InvalidPositionBounds();
+        if (lower % tickSpacing != 0) require(false, 'InvalidLowerTick()');
+        if (lower <= TickMath.MIN_TICK) require(false, 'InvalidLowerTick()');
+        if (upper % tickSpacing != 0) require(false, 'InvalidUpperTick()');
+        if (upper >= TickMath.MAX_TICK) require(false, 'InvalidUpperTick()');
+        if (lower >= upper) require(false, 'InvalidPositionBounds()');
     }
 
     function swap(
@@ -353,8 +353,8 @@ library Ticks {
         //TODO: doesn't check if upper/lowerOld is greater/less than MAX/MIN_TICK
         validate(lower, upper, IRangePool(address(this)).tickSpacing());
         // check for amount to overflow liquidity delta & global
-        if (amount > uint128(type(int128).max)) revert LiquidityOverflow();
-        if (type(uint128).max - state.liquidityGlobal < amount) revert LiquidityOverflow();
+        if (amount > uint128(type(int128).max)) require(false, 'LiquidityOverflow()');
+        if (type(uint128).max - state.liquidityGlobal < amount) require(false, 'LiquidityOverflow()');
 
         // get tick at price
         int24 tickAtPrice = state.tickAtPrice;
@@ -418,8 +418,8 @@ library Ticks {
     ) external returns (IRangePoolStructs.PoolState memory) {
         validate(lower, upper, IRangePool(address(this)).tickSpacing());
         //check for amount to overflow liquidity delta & global
-        if (amount > uint128(type(int128).max)) revert LiquidityUnderflow();
-        if (amount > state.liquidityGlobal) revert LiquidityUnderflow();
+        if (amount > uint128(type(int128).max)) require(false, 'LiquidityUnderflow()');
+        if (amount > state.liquidityGlobal) require(false, 'LiquidityUnderflow()');
 
         // get tick at price
         int24 tickAtPrice = state.tickAtPrice;


### PR DESCRIPTION
This PR replaces all custom errors with `require()` statements so the error strings are visible on Etherscan.