### PR TITLE
Move Protocol Fee to PoolState

### DIFF
--- a/contracts/RangePoolFactory.sol
+++ b/contracts/RangePoolFactory.sol
@@ -11,12 +11,13 @@ contract RangePoolFactory is
     RangePoolFactoryStorage,
     RangePoolFactoryEvents
 {
+    address public immutable owner;
     error InvalidTokenAddress();
     error PoolAlreadyExists();
     error FeeTierNotSupported();
 
-    constructor(address owner_) {
-        _owner = IRangePoolManager(owner_);
+    constructor(address _owner) {
+        owner = _owner;
     }
 
     function createRangePool(
@@ -41,13 +42,13 @@ contract RangePoolFactory is
         }
 
         // check fee tier exists and get tick spacing
-        int24 tickSpacing = _owner.feeTiers(swapFee);
+        int24 tickSpacing = IRangePoolManager(owner).feeTiers(swapFee);
         if (tickSpacing == 0) {
             revert FeeTierNotSupported();
         }
 
         // launch pool and save address
-        pool = address(new RangePool(token0, token1, int24(tickSpacing), swapFee, startPrice, _owner));
+        pool = address(new RangePool(token0, token1, owner, startPrice, int24(tickSpacing), swapFee));
 
         rangePools[key] = pool;
 
@@ -68,9 +69,5 @@ contract RangePoolFactory is
         bytes32 key = keccak256(abi.encode(token0, token1, swapFee));
 
         return rangePools[key];
-    }
-
-    function owner() public view override returns (address) {
-        return address(_owner);
     }
 }

--- a/contracts/base/events/RangePoolManagerEvents.sol
+++ b/contracts/base/events/RangePoolManagerEvents.sol
@@ -6,6 +6,6 @@ abstract contract RangePoolManagerEvents {
     event FeeTierEnabled(uint16 swapFee, int24 tickSpacing);
     event FeeToTransfer(address indexed previousFeeTo, address indexed newFeeTo);
     event OwnerTransfer(address indexed previousOwner, address indexed newOwner);
-    event ProtocolFeeUpdated(address indexed pool, uint16 protocolFee);
-    event ProtocolFeeCollected(address indexed pool, uint128 token0Fees, uint128 token1Fees);
+    event ProtocolFeeUpdated(address[] pool, uint16 protocolFee);
+    event ProtocolFeeCollected(address[] pool, uint128[] token0Fees, uint128[] token1Fees);
 }

--- a/contracts/base/storage/RangePoolFactoryStorage.sol
+++ b/contracts/base/storage/RangePoolFactoryStorage.sol
@@ -4,6 +4,5 @@ pragma solidity 0.8.13;
 import '../../interfaces/IRangePoolManager.sol';
 
 abstract contract RangePoolFactoryStorage {
-    IRangePoolManager public _owner;
     mapping(bytes32 => address) public rangePools;
 }

--- a/contracts/base/storage/RangePoolStorage.sol
+++ b/contracts/base/storage/RangePoolStorage.sol
@@ -10,7 +10,6 @@ import '../../utils/RangePoolErrors.sol';
 
 abstract contract RangePoolStorage is IRangePoolStructs, IRangePool {
     PoolState public poolState;
-    IRangePoolManager public owner;
     TickMap public tickMap;
     //TODO: convert to mapping
     Sample[65535] public samples;

--- a/contracts/interfaces/IRangePool.sol
+++ b/contracts/interfaces/IRangePool.sol
@@ -34,13 +34,16 @@ interface IRangePool is IRangePoolStructs {
         uint16 sampleLengthNext
     ) external;
 
-    function collectProtocolFees() external returns (
+    function protocolFees(
+        uint16 protocolFee,
+        bool setFee
+    ) external returns (
         uint128 token0Fees,
         uint128 token1Fees
     );
 
     function owner() external view returns (
-        IRangePoolManager
+        address
     );
 
     function tickSpacing() external view returns (
@@ -55,8 +58,8 @@ interface IRangePool is IRangePoolStructs {
 
     function poolState() external view returns (
         uint8,
+        uint16,
         int24,
-        uint32,
         int56,
         uint160,
         uint160,
@@ -73,7 +76,6 @@ interface IRangePool is IRangePoolStructs {
         uint200,
         uint200,
         int56,
-        uint160,
-        uint32
+        uint160
     );
 }

--- a/contracts/interfaces/IRangePoolStructs.sol
+++ b/contracts/interfaces/IRangePoolStructs.sol
@@ -6,8 +6,8 @@ import "./IRangePoolERC1155.sol";
 interface IRangePoolStructs {
     struct PoolState {
         uint8   unlocked;
+        uint16  protocolFee;
         int24   tickAtPrice;
-        uint32  secondsGrowthGlobal; /// @dev Multiplied by 2^128
         int56   tickSecondsAccum;
         uint160 secondsPerLiquidityAccum;
         uint160 price;               /// @dev Starting price current
@@ -31,7 +31,6 @@ interface IRangePoolStructs {
         uint200 feeGrowthOutside1;
         int56   tickSecondsAccumOutside;
         uint160 secondsPerLiquidityAccumOutside;
-        uint32  secondsGrowthOutside;
     }
 
     struct TickMap {

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -452,9 +452,9 @@ library Positions {
     ) {
         Ticks.validate(lower, upper, IRangePool(pool).tickSpacing());
         (
-            ,
+            ,,
             int24 currentTick,
-            ,,,,,,
+            ,,,,,
             uint256 _feeGrowthGlobal0,
             uint256 _feeGrowthGlobal1,
             ,
@@ -463,14 +463,14 @@ library Positions {
             ,
             uint216 tickLowerFeeGrowthOutside0,
             uint216 tickLowerFeeGrowthOutside1,
-            ,,
+            ,
         )
             = IRangePool(pool).ticks(lower);
         (
             ,
             uint216 tickUpperFeeGrowthOutside0,
             uint216 tickUpperFeeGrowthOutside1,
-            ,,
+            ,
         )
             = IRangePool(pool).ticks(upper);
 
@@ -529,8 +529,7 @@ library Positions {
         (
             ,,,
             cache.tickSecondsAccumLower,
-            cache.secondsPerLiquidityAccumLower,
-            cache.secondsOutsideLower
+            cache.secondsPerLiquidityAccumLower
         )
             = IRangePool(pool).ticks(lower);
 
@@ -538,8 +537,7 @@ library Positions {
         (
             ,,,
             cache.tickSecondsAccumUpper,
-            cache.secondsPerLiquidityAccumUpper,
-            cache.secondsOutsideUpper
+            cache.secondsPerLiquidityAccumUpper
         )
             = IRangePool(pool).ticks(upper);
 

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -88,7 +88,7 @@ library Ticks {
                                   : TickMap.next(tickMap, pool.tickAtPrice),
             crossPrice: 0,
             swapFee: swapFee,
-            protocolFee: 0,
+            protocolFee: pool.protocolFee,
             input: amountIn,
             output: 0,
             amountIn: amountIn,
@@ -111,7 +111,6 @@ library Ticks {
                 ),
                 0
         );
-        cache.protocolFee = IRangePool(address(this)).owner().protocolFees(address(this));
         while (cache.cross) {
             cache.crossPrice = TickMath.getSqrtRatioAtTick(cache.crossTick);
             (pool, cache) = _quoteSingle(zeroForOne, priceLimit, pool, cache);
@@ -172,14 +171,13 @@ library Ticks {
                                   : TickMap.next(tickMap, pool.tickAtPrice),
             crossPrice: 0,
             swapFee: swapFee,
-            protocolFee: 0,
+            protocolFee: pool.protocolFee,
             input: amountIn,
             output: 0,
             amountIn: amountIn,
             tickSecondsAccum: 0,
             secondsPerLiquidityAccum: 0
         });
-        cache.protocolFee = IRangePool(address(this)).owner().protocolFees(address(this));
         while (cache.cross) {
             cache.crossPrice = TickMath.getSqrtRatioAtTick(cache.crossTick);
             (pool, cache) = _quoteSingle(zeroForOne, priceLimit, pool, cache);
@@ -294,7 +292,6 @@ library Ticks {
         crossTick.feeGrowthOutside0       = pool.feeGrowthGlobal0 - crossTick.feeGrowthOutside0;
         crossTick.feeGrowthOutside1       = pool.feeGrowthGlobal1 - crossTick.feeGrowthOutside1;
         crossTick.tickSecondsAccumOutside = cache.tickSecondsAccum - crossTick.tickSecondsAccumOutside;
-        crossTick.secondsGrowthOutside    = uint32(block.timestamp) - crossTick.secondsGrowthOutside;
         crossTick.secondsPerLiquidityAccumOutside = cache.secondsPerLiquidityAccum - crossTick.secondsPerLiquidityAccumOutside;
         ticks[cache.crossTick] = crossTick;
         // observe most recent oracle update
@@ -378,8 +375,7 @@ library Ticks {
                     state.feeGrowthGlobal0,
                     state.feeGrowthGlobal1,
                     state.tickSecondsAccum,
-                    state.secondsPerLiquidityAccum,
-                    state.secondsGrowthGlobal
+                    state.secondsPerLiquidityAccum
                 );
             } else {
                 ticks[lower].liquidityDelta = int128(amount);
@@ -395,8 +391,7 @@ library Ticks {
                     state.feeGrowthGlobal0,
                     state.feeGrowthGlobal1,
                     state.tickSecondsAccum,
-                    state.secondsPerLiquidityAccum,
-                    state.secondsGrowthGlobal
+                    state.secondsPerLiquidityAccum
                 );
             } else {
                 ticks[upper].liquidityDelta = -int128(amount);

--- a/contracts/utils/RangePoolErrors.sol
+++ b/contracts/utils/RangePoolErrors.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.13;
 
 abstract contract RangePoolErrors {
     error Locked();
-    error FactoryOnly();
+    error ManagerOnly();
     error InvalidToken();
     error InvalidPosition();
     error InvalidSwapFee();

--- a/contracts/utils/RangePoolManager.sol
+++ b/contracts/utils/RangePoolManager.sol
@@ -17,6 +17,7 @@ contract RangePoolManager is
     address public _owner;
     address private _feeTo;
     address private _factory;
+    uint16 internal constant MAX_FEE = 1e4; // @dev - max fee of 1%
 
     mapping(uint16 => int24)   public feeTiers;
     mapping(address => uint16) public protocolFees;
@@ -26,6 +27,7 @@ contract RangePoolManager is
     error FeeTierAlreadyEnabled();
     error TransferredToZeroAddress();
     error FeeTierTickSpacingInvalid();
+    error ProtocolFeeMaxExceeded();
     
     constructor() {
         _owner = msg.sender;
@@ -145,6 +147,7 @@ contract RangePoolManager is
         address[] calldata addPools,
         uint16 protocolFee
     ) external onlyOwner {
+        if (protocolFee > MAX_FEE) revert ProtocolFeeMaxExceeded();
         uint128[] memory token0Fees = new uint128[](removePools.length);
         uint128[] memory token1Fees = new uint128[](removePools.length);
         for (uint i; i < removePools.length; i++) {

--- a/contracts/utils/RangePoolManager.sol
+++ b/contracts/utils/RangePoolManager.sol
@@ -145,23 +145,34 @@ contract RangePoolManager is
         address[] calldata addPools,
         uint16 protocolFee
     ) external onlyOwner {
+        uint128[] memory token0Fees = new uint128[](removePools.length);
+        uint128[] memory token1Fees = new uint128[](removePools.length);
         for (uint i; i < removePools.length; i++) {
-            protocolFees[removePools[i]] = 0;
-            emit ProtocolFeeUpdated(removePools[i], 0);
+            (token0Fees[i], token1Fees[i]) = IRangePool(removePools[i]).protocolFees(0, true); 
         }
+        if (removePools.length > 0) {
+            emit ProtocolFeeUpdated(removePools, protocolFee);
+            emit ProtocolFeeCollected(removePools, token0Fees, token1Fees);
+        }
+        token0Fees = new uint128[](addPools.length);
+        token1Fees = new uint128[](addPools.length);
         for (uint i; i < addPools.length; i++) {
-            protocolFees[addPools[i]] = protocolFee;
-            emit ProtocolFeeUpdated(addPools[i], protocolFee);
+            (token0Fees[i], token1Fees[i]) = IRangePool(addPools[i]).protocolFees(protocolFee, true);
+        }
+        if (addPools.length > 0) {
+            emit ProtocolFeeUpdated(removePools, protocolFee);
+            emit ProtocolFeeCollected(removePools, token0Fees, token1Fees);
         }
     }
 
     function collectTopPools(
         address[] calldata collectPools
     ) external onlyFeeTo {
+        uint128[] memory token0Fees = new uint128[](collectPools.length);
+        uint128[] memory token1Fees = new uint128[](collectPools.length);
         for (uint i; i < collectPools.length; i++) {
-            uint128 token0Fees; uint128 token1Fees;
-            (token0Fees, token1Fees) = IRangePool(collectPools[i]).collectProtocolFees();
-            emit ProtocolFeeCollected(collectPools[i], token0Fees, token1Fees);
+            (token0Fees[i], token1Fees[i]) = IRangePool(collectPools[i]).protocolFees(0, false);
+            emit ProtocolFeeCollected(collectPools, token0Fees, token1Fees);
         }
     }
 }

--- a/test/contracts/rangepoolmanager.ts
+++ b/test/contracts/rangepoolmanager.ts
@@ -136,21 +136,20 @@ describe('RangePoolAdmin Tests', function () {
     // set protocol fees on top pools
     await hre.props.rangePoolManager.connect(hre.props.admin).setTopPools([], [hre.props.rangePool.address], "500")
     // check new fee set
-    expect(await
-        hre.props.rangePoolManager
-          .protocolFees(hre.props.rangePool.address)
+    expect((await
+        hre.props.rangePool.poolState())
+          .protocolFee
       ).to.be.equal(500)
-    
     await hre.props.rangePoolManager.connect(hre.props.admin).transferOwner(hre.props.bob.address)
 
     // remove protocol fees on top pools
     await hre.props.rangePoolManager.connect(hre.props.bob).setTopPools([hre.props.rangePool.address], [], "500")
 
     // check new fee set
-    expect(await
-        hre.props.rangePoolManager
-            .protocolFees(hre.props.rangePool.address)
-        ).to.be.equal(0)
+    expect((await
+      hre.props.rangePool.poolState())
+        .protocolFee
+    ).to.be.equal(0)
 
     // should revert when non-admin calls
     await expect(


### PR DESCRIPTION
This PR moves the protocolFee value to the `poolState` contract storage struct.

This almost emits event related to collecting and updating the protocol fee.

We also add here a MAX_FEE for the protocolFee, which is `1e4` or 1%.