### PR TITLE
Tickmap Packing

### DIFF
--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -104,7 +104,6 @@ contract RangePool is
                 )
             );
         }
-        //TODO: if fees > 0 emit PositionUpdated event
         // update position with latest fees accrued
         (pool, position, liquidityMinted) = Positions.add(
             position,

--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -63,7 +63,8 @@ contract RangePool is
         pool = Ticks.initialize(
             tickMap,
             samples,
-            pool
+            pool,
+            tickSpacing
         );
 
         // save pool state

--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -41,9 +41,6 @@ contract RangePool is
         int24 _tickSpacing,
         uint16 _swapFee
     ) {
-        // validate start price
-        TickMath.validatePrice(_startPrice);
-
         // set addresses
         token0 = _token0;
         token1 = _token1;
@@ -258,7 +255,6 @@ contract RangePool is
         uint256,
         uint160
     ) {
-        // figure out price limit for user
         // quote with low price limit
         PoolState memory pool = poolState;
         SwapCache memory cache;

--- a/contracts/base/storage/RangePoolStorage.sol
+++ b/contracts/base/storage/RangePoolStorage.sol
@@ -11,9 +11,8 @@ import '../../utils/RangePoolErrors.sol';
 abstract contract RangePoolStorage is IRangePoolStructs, IRangePool {
     PoolState public poolState;
     TickMap public tickMap;
-    //TODO: convert to mapping
     Sample[65535] public samples;
-    mapping(int24 => Tick) public ticks;        /// @dev - liquidity and fee data
+    mapping(int24 => Tick) public ticks; /// @dev - liquidity and fee data
     //TODO: no address needed if all are owned by the pool
     mapping(address => mapping(int24 => mapping(int24 => Position))) public positions; /// @dev - nonfungible positions
 }

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -274,5 +274,4 @@ library TickMap {
     ) {
         return tick / tickSpacing * tickSpacing;
     }
-    
 }

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -206,8 +206,8 @@ library Ticks {
             IRangePoolStructs.PoolState memory,
             IRangePoolStructs.SwapCache memory
     ) {
-        if (zeroForOne ? priceLimit >= pool.price || pool.price == TickMath.MIN_SQRT_RATIO
-                       : priceLimit <= pool.price || pool.price == TickMath.MAX_SQRT_RATIO)
+        if (zeroForOne ? priceLimit >= pool.price
+                       : priceLimit <= pool.price)
         {
             cache.cross = false;
             return (pool, cache);

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -11,7 +11,6 @@ import './PrecisionMath.sol';
 import './TickMath.sol';
 import './TickMap.sol';
 import './Samples.sol';
-import 'hardhat/console.sol';
 
 /// @notice Tick management library
 library Ticks {
@@ -46,8 +45,6 @@ library Ticks {
         IRangePoolStructs.PoolState memory
     )    
     {
-        console.log('tick spacing check:');
-        console.logInt(tickSpacing);
         TickMap.init(tickMap, TickMath.MIN_TICK, tickSpacing);
         TickMap.init(tickMap, TickMath.MAX_TICK, tickSpacing);
         state.tickAtPrice = TickMath.getTickAtSqrtRatio(state.price);

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -48,8 +48,8 @@ library Ticks {
     {
         console.log('tick spacing check:');
         console.logInt(tickSpacing);
-        TickMap.init(tickMap, TickMath.MIN_TICK / tickSpacing * tickSpacing, tickSpacing);
-        TickMap.init(tickMap, TickMath.MAX_TICK / tickSpacing * tickSpacing, tickSpacing);
+        TickMap.init(tickMap, TickMath.MIN_TICK, tickSpacing);
+        TickMap.init(tickMap, TickMath.MAX_TICK, tickSpacing);
         state.tickAtPrice = TickMath.getTickAtSqrtRatio(state.price);
         return Samples.initialize(
             samples,

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -45,12 +45,14 @@ library Ticks {
         IRangePoolStructs.PoolState memory
     )    
     {
+        uint160 minPrice = TickMath.getSqrtRatioAtTick(TickMap._round(TickMath.MIN_TICK, tickSpacing));
+        uint160 maxPrice = TickMath.getSqrtRatioAtTick(TickMap._round(TickMath.MAX_TICK, tickSpacing));
+        if (state.price < minPrice || state.price >= maxPrice) require(false, 'StartPriceInvalid()');
         TickMap.init(tickMap, TickMath.MIN_TICK, tickSpacing);
         TickMap.init(tickMap, TickMath.MAX_TICK, tickSpacing);
         state.tickAtPrice = TickMath.getTickAtSqrtRatio(state.price);
-        return Samples.initialize(
-            samples,
-            state
+        return (
+            Samples.initialize(samples, state)
         );
     }
 
@@ -239,9 +241,8 @@ library Ticks {
             } else { 
                 amountOut = DyDxMath.getDy(pool.liquidity, nextPrice, pool.price, false);
                 cache.input -= maxDx;
-                if (nextPrice == cache.crossPrice 
-                        && nextPrice != pool.price
-                        && cache.crossTick != TickMath.MIN_TICK) { cache.cross = true; }
+                if (nextPrice == cache.crossPrice
+                        && nextPrice != pool.price) { cache.cross = true; }
                 else cache.cross = false;
                 pool.price = uint160(nextPrice);
             }
@@ -266,8 +267,7 @@ library Ticks {
                 amountOut = DyDxMath.getDx(pool.liquidity, pool.price, nextPrice, false);
                 cache.input -= maxDy;
                 if (nextPrice == cache.crossPrice 
-                    && nextPrice != pool.price
-                    && cache.crossTick != TickMath.MAX_TICK) { cache.cross = true; }
+                    && nextPrice != pool.price) { cache.cross = true; }
                 else cache.cross = false;
                 pool.price = uint160(nextPrice);
             }

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -11,6 +11,7 @@ import './PrecisionMath.sol';
 import './TickMath.sol';
 import './TickMap.sol';
 import './Samples.sol';
+import 'hardhat/console.sol';
 
 /// @notice Tick management library
 library Ticks {
@@ -39,13 +40,16 @@ library Ticks {
     function initialize(
         IRangePoolStructs.TickMap storage tickMap,
         IRangePoolStructs.Sample[65535] storage samples,
-        IRangePoolStructs.PoolState memory state
+        IRangePoolStructs.PoolState memory state,
+        int24 tickSpacing
     ) external returns (
         IRangePoolStructs.PoolState memory
     )    
     {
-        TickMap.set(tickMap, TickMath.MIN_TICK);
-        TickMap.set(tickMap, TickMath.MAX_TICK);
+        console.log('tick spacing check:');
+        console.logInt(tickSpacing);
+        TickMap.init(tickMap, TickMath.MIN_TICK / tickSpacing * tickSpacing, tickSpacing);
+        TickMap.init(tickMap, TickMath.MAX_TICK / tickSpacing * tickSpacing, tickSpacing);
         state.tickAtPrice = TickMath.getTickAtSqrtRatio(state.price);
         return Samples.initialize(
             samples,

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -230,10 +230,6 @@ library Ticks {
                     pool.price,
                     liquidityPadded + uint256(pool.price) * uint256(cache.input)
                 );
-                /// @auditor - check tests to see if we need overflow handle
-                // if (!(nextTickPrice <= newPrice && newPrice < pool.price)) {
-                //     newPrice = uint160(PrecisionMath.divRoundingUp(liquidityPadded, liquidityPadded / pool.price + cache.input));
-                //  }
                 amountOut = DyDxMath.getDy(pool.liquidity, newPrice, uint256(pool.price), false);
                 cache.input = 0;
                 cache.cross = false;
@@ -275,8 +271,6 @@ library Ticks {
         (pool, cache) = FeeMath.calculate(pool, cache, amountOut, zeroForOne);
         return (pool, cache);
     }
-
-    //TODO: set custom metadata for NFT pic
 
     //maybe call ticks on msg.sender to get tick
     function _cross(
@@ -338,7 +332,6 @@ library Ticks {
         return (pool, cache);
     }
 
-    //TODO: pass in lowerTick and upperTick
     function insert(
         mapping(int24 => IRangePoolStructs.Tick) storage ticks,
         IRangePoolStructs.Sample[65535] storage samples,
@@ -348,7 +341,6 @@ library Ticks {
         int24 upper,
         uint128 amount
     ) external returns (IRangePoolStructs.PoolState memory) {
-        //TODO: doesn't check if upper/lowerOld is greater/less than MAX/MIN_TICK
         validate(lower, upper, IRangePool(address(this)).tickSpacing());
         // check for amount to overflow liquidity delta & global
         if (amount > uint128(type(int128).max)) require(false, 'LiquidityOverflow()');

--- a/contracts/utils/RangePoolErrors.sol
+++ b/contracts/utils/RangePoolErrors.sol
@@ -4,16 +4,6 @@ pragma solidity 0.8.13;
 abstract contract RangePoolErrors {
     error Locked();
     error ManagerOnly();
-    error InvalidToken();
-    error InvalidPosition();
-    error InvalidSwapFee();
-    error InvalidTickSpread();
-    error LiquidityOverflow();
-    error RangeErc20NotFound();
-    error RangeErc20InsufficientBalance();
-    error InvalidTick();
-    error NotEnoughOutputLiquidity();
-    error WaitUntilEnoughObservations();
 }
 
 abstract contract RangePoolERC1155Errors {

--- a/subgraph/src/mappings/rangepoolfactory.ts
+++ b/subgraph/src/mappings/rangepoolfactory.ts
@@ -62,7 +62,7 @@ export function handleRangePoolCreated(event: RangePoolCreated): void {
         }
         token1.decimals = decimals
     }
-    //TODO: calculate tick at initial sqrt price
+    // calculate tick at initial sqrt price
 
     pool.token0 = token0.id
     pool.token1 = token1.id

--- a/tasks/deploy/utils/mintPosition.ts
+++ b/tasks/deploy/utils/mintPosition.ts
@@ -42,7 +42,7 @@ export class MintPosition {
       amount0: token0Amount,
       amount1: token1Amount,
       fungible: false,
-      balance0Decrease: BigNumber.from('0'), //TODO: make optional
+      balance0Decrease: BigNumber.from('0'),
       balance1Decrease: token1Amount,
       liquidityIncrease: liquidityAmount,
       revertMessage: '',

--- a/test/contracts/libraries/dydxmath.ts
+++ b/test/contracts/libraries/dydxmath.ts
@@ -17,13 +17,12 @@ describe('DyDxMath Library Tests', function () {
   let bob: SignerWithAddress
   let carol: SignerWithAddress
 
-  //TODO: mint position and burn as if there were 100
+
 
   before(async function () {
     await gBefore()
     let currentBlock = await ethers.provider.getBlockNumber()
-    //TODO: maybe just have one view function that grabs all these
-    //TODO: map it to an interface
+
     const pool: PoolState = await hre.props.rangePool.poolState()
     const liquidity = pool.liquidity
     const price = pool.price

--- a/test/contracts/libraries/positions.ts
+++ b/test/contracts/libraries/positions.ts
@@ -17,13 +17,12 @@ describe('Positions Library Tests', function () {
   let bob: SignerWithAddress
   let carol: SignerWithAddress
 
-  //TODO: mint position and burn as if there were 100
+
 
   before(async function () {
     await gBefore()
     let currentBlock = await ethers.provider.getBlockNumber()
-    //TODO: maybe just have one view function that grabs all these
-    //TODO: map it to an interface
+
     const pool: PoolState = await hre.props.rangePool.poolState()
     const liquidity = pool.liquidity
     const price = pool.price

--- a/test/contracts/libraries/precisionmath.ts
+++ b/test/contracts/libraries/precisionmath.ts
@@ -17,13 +17,12 @@ describe('PrecisionMath Library Tests', function () {
   let bob: SignerWithAddress
   let carol: SignerWithAddress
 
-  //TODO: mint position and burn as if there were 100
+
 
   before(async function () {
     await gBefore()
     let currentBlock = await ethers.provider.getBlockNumber()
-    //TODO: maybe just have one view function that grabs all these
-    //TODO: map it to an interface
+
     const pool: PoolState = await hre.props.rangePool.poolState()
     const liquidity = pool.liquidity
     const price = pool.price

--- a/test/contracts/libraries/samples.ts
+++ b/test/contracts/libraries/samples.ts
@@ -20,13 +20,12 @@ describe('Samples Library Tests', function () {
   const tokenAmount = ethers.utils.parseUnits('100', token1Decimals)
   const maxPrice = BigNumber.from('1461446703485210103287273052203988822378723970341')
 
-  //TODO: mint position and burn as if there were 100
+
 
   before(async function () {
     await gBefore()
     let currentBlock = await ethers.provider.getBlockNumber()
-    //TODO: maybe just have one view function that grabs all these
-    //TODO: map it to an interface
+
     const pool: PoolState = await hre.props.rangePool.poolState()
     const liquidity = pool.liquidity
     const price = pool.price

--- a/test/contracts/libraries/tickmath.ts
+++ b/test/contracts/libraries/tickmath.ts
@@ -17,13 +17,12 @@ describe('TickMath Library Tests', function () {
   let bob: SignerWithAddress
   let carol: SignerWithAddress
 
-  //TODO: mint position and burn as if there were 100
+
 
   before(async function () {
     await gBefore()
     let currentBlock = await ethers.provider.getBlockNumber()
-    //TODO: maybe just have one view function that grabs all these
-    //TODO: map it to an interface
+
     const pool0: PoolState = await hre.props.rangePool.poolState()
     const liquidity = pool0.liquidity
     const price = pool0.price

--- a/test/contracts/libraries/ticks.ts
+++ b/test/contracts/libraries/ticks.ts
@@ -17,13 +17,12 @@ describe('Ticks Library Tests', function () {
   let bob: SignerWithAddress
   let carol: SignerWithAddress
 
-  //TODO: mint position and burn as if there were 100
+
 
   before(async function () {
     await gBefore()
     let currentBlock = await ethers.provider.getBlockNumber()
-    //TODO: maybe just have one view function that grabs all these
-    //TODO: map it to an interface
+
     const pool: PoolState = await hre.props.rangePool.poolState()
     const liquidity = pool.liquidity
     const price = pool.price

--- a/test/contracts/rangepoolfactory.ts
+++ b/test/contracts/rangepoolfactory.ts
@@ -21,7 +21,7 @@ describe('RangePoolFactory Tests', function () {
   const minTickIdx = BigNumber.from('-887272')
   const maxTickIdx = BigNumber.from('887272')
 
-  //TODO: mint position and burn as if there were 100
+
 
   before(async function () {
     await gBefore()

--- a/test/contracts/rangepoolmanager.ts
+++ b/test/contracts/rangepoolmanager.ts
@@ -22,7 +22,7 @@ describe('RangePoolAdmin Tests', function () {
   const minTickIdx = BigNumber.from('-887272')
   const maxTickIdx = BigNumber.from('887272')
 
-  //TODO: mint position and burn as if there were 100
+
 
   before(async function () {
     await gBefore()

--- a/test/utils/contracts/rangepool.ts
+++ b/test/utils/contracts/rangepool.ts
@@ -175,7 +175,7 @@ export async function validateSwap(params: ValidateSwapParams) {
   const priceAfter = poolAfter.price
 
   expect(priceAfter).to.be.equal(priceAfterQuote)
-  //TODO: check feeGrowth before and after swap
+  // check feeGrowth before and after swap
 
   // expect(liquidityAfter).to.be.equal(finalLiquidity);
   // expect(priceAfter).to.be.equal(finalPrice);
@@ -368,7 +368,6 @@ export async function validateBurn(params: ValidateBurnParams) {
         collect: true
     })
     await burnTxn.wait()
-    //TODO: expect balances to remain unchanged until collect
   } else {
     await expect(
       hre.props.rangePool.connect(signer).burn({


### PR DESCRIPTION
This PR implements tickmap packing.

We always round MIN_TICK and MAX_TICK based on the spacing.

When calling `next()`, we round down based on the tickSpacing when `tickAtPrice % tickSpacing != 0`.

For `previous()`, we round up for `previous()` when `tickAtPrice % tickSpacing != 0`.

This should only be true if `pool.tickAtPrice` is between valid ticks (i.e. tick % tickSpacing == 0).

When the price does not change in between tick iterations, we exit the tick iteration loop and stop crossing.