### PR TITLE
Reduce calldata by using call libraries

### DIFF
--- a/contracts/interfaces/IRangePool.sol
+++ b/contracts/interfaces/IRangePool.sol
@@ -5,25 +5,23 @@ import './IRangePoolStructs.sol';
 import './IRangePoolManager.sol';
 
 interface IRangePool is IRangePoolStructs {
-    function mint(MintParams calldata mintParams) external;
+    function mint(
+        MintParams memory mintParams
+    ) external;
 
-    function burn(BurnParams calldata burnParams) external;
+    function burn(
+        BurnParams memory burnParams
+    ) external;
 
     function swap(
-        address recipient,
-        address refundRecipient,
-        bool zeroForOne,
-        uint256 amountIn,
-        uint160 priceLimit
+        SwapParams memory params
     ) external returns (
         int256 amount0,
         int256 amount1
     );
 
     function quote(
-        bool zeroForOne,
-        uint256 amountIn,
-        uint160 priceLimit
+        QuoteParams memory params
     ) external view returns (
         uint256 inAmount,
         uint256 outAmount,

--- a/contracts/interfaces/IRangePoolStructs.sol
+++ b/contracts/interfaces/IRangePoolStructs.sol
@@ -64,6 +64,8 @@ interface IRangePoolStructs {
     }
 
     struct Immutables {
+        address token0;
+        address token1;
         uint16 swapFee;
         int24  tickSpacing;
     }
@@ -95,10 +97,17 @@ interface IRangePoolStructs {
     }
 
     struct SwapParams {
-        address recipient;
-        bool zeroForOne;
+        address to;
+        address refundTo;
         uint160 priceLimit;
-        uint256 amountIn;
+        uint128 amountIn;
+        bool zeroForOne;
+    }
+
+    struct QuoteParams {
+        uint160 priceLimit;
+        uint128 amountIn;
+        bool zeroForOne;
     }
 
     struct SampleParams {
@@ -130,17 +139,27 @@ interface IRangePoolStructs {
 
     struct MintCache {
         PoolState pool;
-        MintParams params;
         Position position;
+        Immutables constants;
+        uint256 liquidityMinted;
+    }
+
+    struct BurnCache {
+        PoolState pool;
+        Position position;
+        Immutables constants;
+        uint128 amount0;
+        uint128 amount1;
     }
 
     struct SwapCache {
+        Immutables constants;
+        PoolState pool;
         uint160 price;
         uint128 liquidity;
         bool    cross;
         int24   crossTick;
         uint160 crossPrice;
-        uint16  swapFee;
         uint16  protocolFee;
         int56   tickSecondsAccum;
         uint160 secondsPerLiquidityAccum;

--- a/contracts/libraries/DyDxMath.sol
+++ b/contracts/libraries/DyDxMath.sol
@@ -15,24 +15,6 @@ library DyDxMath {
         uint256 priceLower,
         uint256 priceUpper,
         bool roundUp
-    ) external pure returns (uint256 dy) {
-        return _getDy(liquidity, priceLower, priceUpper, roundUp);
-    }
-
-    function getDx(
-        uint256 liquidity,
-        uint256 priceLower,
-        uint256 priceUpper,
-        bool roundUp
-    ) external pure returns (uint256 dx) {
-        return _getDx(liquidity, priceLower, priceUpper, roundUp);
-    }
-
-    function _getDy(
-        uint256 liquidity,
-        uint256 priceLower,
-        uint256 priceUpper,
-        bool roundUp
     ) internal pure returns (uint256 dy) {
         unchecked {
             if (roundUp) {
@@ -43,7 +25,7 @@ library DyDxMath {
         }
     }
 
-    function _getDx(
+    function getDx(
         uint256 liquidity,
         uint256 priceLower,
         uint256 priceUpper,
@@ -71,7 +53,7 @@ library DyDxMath {
         uint256 currentPrice,
         uint256 dy,
         uint256 dx
-    ) external pure returns (uint256 liquidity) {
+    ) internal pure returns (uint256 liquidity) {
         unchecked {
             if (priceUpper <= currentPrice) {
                 liquidity = PrecisionMath.mulDiv(dy, Q96, priceUpper - priceLower);
@@ -99,21 +81,21 @@ library DyDxMath {
         uint256 currentPrice,
         uint256 liquidityAmount,
         bool roundUp
-    ) external pure returns (
+    ) internal pure returns (
         uint128,
         uint128
     ) {
         uint256 dx; uint256 dy;
         if (currentPrice <= priceLower) {
             // token0 (X) is supplied
-            dx = _getDx(liquidityAmount, priceLower, priceUpper, roundUp);
+            dx = getDx(liquidityAmount, priceLower, priceUpper, roundUp);
         } else if (priceUpper <= currentPrice) {
             // token1 (y) is supplied
-            dy = _getDy(liquidityAmount, priceLower, priceUpper, roundUp);
+            dy = getDy(liquidityAmount, priceLower, priceUpper, roundUp);
         } else {
             // Both token0 (x) and token1 (y) are supplied
-            dx = _getDx(liquidityAmount, currentPrice, priceUpper, roundUp);
-            dy = _getDy(liquidityAmount, priceLower, currentPrice, roundUp);
+            dx = getDx(liquidityAmount, currentPrice, priceUpper, roundUp);
+            dy = getDy(liquidityAmount, priceLower, currentPrice, roundUp);
         }
         if (dx > uint128(type(int128).max)) require(false, 'AmountsOutOfBounds()');
         if (dy > uint128(type(int128).max)) require(false, 'AmountsOutOfBounds()');

--- a/contracts/libraries/FeeMath.sol
+++ b/contracts/libraries/FeeMath.sol
@@ -19,7 +19,7 @@ library FeeMath {
     )
     {
         if (cache.liquidity == 0 ) return (pool, cache);
-        uint256 feeAmount = PrecisionMath.mulDivRoundingUp(amountOut, cache.swapFee, 1e6); 
+        uint256 feeAmount = PrecisionMath.mulDivRoundingUp(amountOut, cache.constants.swapFee, 1e6); 
         uint256 protocolFee = PrecisionMath.mulDivRoundingUp(feeAmount, cache.protocolFee, 1e6);
         amountOut -= feeAmount;
         feeAmount -= protocolFee;

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -60,7 +60,7 @@ library Positions {
         IRangePoolStructs.MintParams memory params,
         IRangePoolStructs.PoolState memory state,
         IRangePoolStructs.Immutables memory constants
-    ) external pure returns (IRangePoolStructs.MintParams memory, uint256 liquidityMinted) {
+    ) internal pure returns (IRangePoolStructs.MintParams memory, uint256 liquidityMinted) {
         Ticks.validate(params.lower, params.upper, constants.tickSpacing);
         
         uint256 priceLower = uint256(TickMath.getSqrtRatioAtTick(params.lower));
@@ -92,7 +92,7 @@ library Positions {
         IRangePoolStructs.Sample[65535] storage samples,
         IRangePoolStructs.TickMap storage tickMap,
         IRangePoolStructs.AddParams memory params
-    ) external returns (
+    ) internal returns (
         IRangePoolStructs.PoolState memory,
         IRangePoolStructs.Position memory,
         uint128
@@ -169,7 +169,7 @@ library Positions {
         IRangePoolStructs.PoolState memory state,
         IRangePoolStructs.BurnParams memory params,
         IRangePoolStructs.RemoveParams memory removeParams
-    ) external returns (
+    ) internal returns (
         IRangePoolStructs.PoolState memory,
         IRangePoolStructs.Position memory,
         uint128,
@@ -240,7 +240,7 @@ library Positions {
         IRangePoolStructs.TickMap storage tickMap,
         IRangePoolStructs.PoolState memory state,
         IRangePoolStructs.CompoundParams memory params
-    ) external returns (IRangePoolStructs.Position memory, IRangePoolStructs.PoolState memory) {
+    ) internal returns (IRangePoolStructs.Position memory, IRangePoolStructs.PoolState memory) {
         IRangePoolStructs.PositionCache memory cache = IRangePoolStructs.PositionCache({
             priceLower: TickMath.getSqrtRatioAtTick(params.lower),
             priceUpper: TickMath.getSqrtRatioAtTick(params.upper),
@@ -295,7 +295,7 @@ library Positions {
         IRangePoolStructs.Position memory position,
         IRangePoolStructs.PoolState memory state,
         IRangePoolStructs.UpdateParams memory params
-    ) external returns (
+    ) internal returns (
         IRangePoolStructs.Position memory, 
         uint128, 
         uint128

--- a/contracts/libraries/PrecisionMath.sol
+++ b/contracts/libraries/PrecisionMath.sol
@@ -5,16 +5,8 @@ pragma solidity 0.8.13;
 library PrecisionMath {
     error MaxUintExceeded();
 
-    function mulDiv(
-        uint256 a,
-        uint256 b,
-        uint256 denominator
-    ) external pure returns (uint256 result) {
-        return _mulDiv(a, b, denominator);
-    }
-
     // @dev no underflow or overflow checks
-    function divRoundingUp(uint256 x, uint256 y) external pure returns (uint256 z) {
+    function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
         assembly {
             z := add(div(x, y), gt(mod(x, y), 0))
         }
@@ -24,7 +16,7 @@ library PrecisionMath {
         uint256 a,
         uint256 b,
         uint256 denominator
-    ) external pure returns (uint256 result) {
+    ) internal pure returns (uint256 result) {
         return _mulDivRoundingUp(a, b, denominator);
     }
 
@@ -34,7 +26,7 @@ library PrecisionMath {
     /// @param denominator The divisor.
     /// @return result The 256-bit result.
     /// @dev Credit to Remco Bloemen under MIT license https://xn--2-umb.com/21/muldiv.
-    function _mulDiv(
+    function mulDiv(
         uint256 a,
         uint256 b,
         uint256 denominator
@@ -132,7 +124,7 @@ library PrecisionMath {
         uint256 b,
         uint256 denominator
     ) internal pure returns (uint256 result) {
-        result = _mulDiv(a, b, denominator);
+        result = mulDiv(a, b, denominator);
         unchecked {
             if (mulmod(a, b, denominator) != 0) {
                 if (result >= type(uint256).max) revert MaxUintExceeded();

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -84,7 +84,7 @@ library Samples {
     ) {
         if (state.samples.length == 0) require(false, 'SampleArrayUninitialized()');
         if (sampleLengthNext <= state.samples.lengthNext) return state;
-        if (sampleLengthNext >= 65535)
+        if (sampleLengthNext >= 65535) return state;
         for (uint16 i = state.samples.lengthNext; i < sampleLengthNext; i++) {
             samples[i].blockTimestamp = 1;
         }

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -84,7 +84,7 @@ library Samples {
     ) {
         if (state.samples.length == 0) require(false, 'SampleArrayUninitialized()');
         if (sampleLengthNext <= state.samples.lengthNext) return state;
-        if (sampleLengthNext >= 65535) return state;
+        if (sampleLengthNext > 65535) return state;
         for (uint16 i = state.samples.lengthNext; i < sampleLengthNext; i++) {
             samples[i].blockTimestamp = 1;
         }

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -22,7 +22,7 @@ library Samples {
     function initialize(
         IRangePoolStructs.Sample[65535] storage samples,
         IRangePoolStructs.PoolState memory state
-    ) external returns (
+    ) internal returns (
         IRangePoolStructs.PoolState memory
     )
     {
@@ -48,7 +48,7 @@ library Samples {
         IRangePoolStructs.Sample[65535] storage samples,
         IRangePoolStructs.PoolState memory state,
         int24  tick
-    ) external returns (
+    ) internal returns (
         uint16 sampleIndexNew,
         uint16 sampleLengthNew
     ) {
@@ -79,7 +79,7 @@ library Samples {
         IRangePoolStructs.Sample[65535] storage samples,
         IRangePoolStructs.PoolState memory state,
         uint16 sampleLengthNext
-    ) external returns (
+    ) internal returns (
         IRangePoolStructs.PoolState memory
     ) {
         if (sampleLengthNext <= state.samples.lengthNext) return state;
@@ -94,7 +94,7 @@ library Samples {
     function get(
         address pool,
         IRangePoolStructs.SampleParams memory params
-    ) external view returns (
+    ) internal view returns (
         int56[]   memory tickSecondsAccum,
         uint160[] memory secondsPerLiquidityAccum
     ) {
@@ -138,7 +138,7 @@ library Samples {
         IRangePool pool,
         IRangePoolStructs.SampleParams memory params,
         uint32 secondsAgo
-    ) public view returns (
+    ) internal view returns (
         int56   tickSecondsAccum,
         uint160 secondsPerLiquidityAccum
     ) {
@@ -234,6 +234,7 @@ library Samples {
     ) {
         int56 timeDelta = int56(uint56(blockTimestamp - newSample.blockTimestamp));
         return
+        //(sample1.tickSecondsAccum - sample2.tickSecondsAccum) / (time2 - time1)
             IRangePoolStructs.Sample({
                 blockTimestamp: blockTimestamp,
                 tickSecondsAccum: newSample.tickSecondsAccum + int56(tick) * int32(timeDelta),

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -55,8 +55,8 @@ library Samples {
         // grab the latest sample
         IRangePoolStructs.Sample memory newSample = samples[state.samples.index];
 
-        // early return if newest sample within 5 seconds
-        if (newSample.blockTimestamp + 5 >= uint32(block.timestamp))
+        // early return if timestamp has not advanced 2 seconds
+        if (newSample.blockTimestamp + 2 > uint32(block.timestamp))
             return (state.samples.index, state.samples.length);
 
         if (state.samples.lengthNext > state.samples.length
@@ -83,8 +83,10 @@ library Samples {
         IRangePoolStructs.PoolState memory
     ) {
         if (state.samples.length == 0) require(false, 'SampleArrayUninitialized()');
+        if (sampleLengthNext <= state.samples.lengthNext) return state;
+        if (sampleLengthNext >= 65535)
         for (uint16 i = state.samples.lengthNext; i < sampleLengthNext; i++) {
-            samples[i].tickSecondsAccum = 1;
+            samples[i].blockTimestamp = 1;
         }
         state.samples.lengthNext = sampleLengthNext;
         emit SampleLengthIncreased(sampleLengthNext);

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -82,9 +82,7 @@ library Samples {
     ) external returns (
         IRangePoolStructs.PoolState memory
     ) {
-        if (state.samples.length == 0) require(false, 'SampleArrayUninitialized()');
         if (sampleLengthNext <= state.samples.lengthNext) return state;
-        if (sampleLengthNext > 65535) return state;
         for (uint16 i = state.samples.lengthNext; i < sampleLengthNext; i++) {
             samples[i].blockTimestamp = 1;
         }

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -16,7 +16,7 @@ library TickMap {
         IRangePoolStructs.TickMap storage tickMap,
         int24 tick,
         int24 tickSpacing
-    ) external returns (
+    ) internal returns (
         bool exists
     )    
     {
@@ -26,7 +26,7 @@ library TickMap {
     function set(
         IRangePoolStructs.TickMap storage tickMap,
         int24 tick
-    ) external returns (
+    ) internal returns (
         bool exists
     )    
     {
@@ -37,7 +37,7 @@ library TickMap {
     function unset(
         IRangePoolStructs.TickMap storage tickMap,
         int24 tick
-    ) external {
+    ) internal {
         int24 tickSpacing = IRangePool(address(this)).tickSpacing();
         (
             uint256 tickIndex,
@@ -57,7 +57,7 @@ library TickMap {
     function previous(
         IRangePoolStructs.TickMap storage tickMap,
         int24 tick
-    ) external view returns (
+    ) internal view returns (
         int24 previousTick
     ) {
         unchecked {
@@ -90,7 +90,7 @@ library TickMap {
     function next(
         IRangePoolStructs.TickMap storage tickMap,
         int24 tick
-    ) external view returns (
+    ) internal view returns (
         int24 nextTick
     ) {
         unchecked {

--- a/contracts/libraries/TickMath.sol
+++ b/contracts/libraries/TickMath.sol
@@ -16,20 +16,12 @@ library TickMath {
     error TickOutOfBounds();
     error PriceOutOfBounds();
 
-    function getSqrtRatioAtTick(int24 tick) external pure returns (uint160 getSqrtPriceX96) {
-        return _getSqrtRatioAtTick(tick);
-    }
-
-    function getTickAtSqrtRatio(uint160 sqrtPriceX96) external pure returns (int24 tick) {
-        return _getTickAtSqrtRatio(sqrtPriceX96);
-    }
-
     /// @notice Calculates sqrt(1.0001^tick) * 2^96.
     /// @dev Throws if |tick| > max tick.
     /// @param tick The input tick for the above formula.
     /// @return sqrtPriceX96 Fixed point Q64.96 number representing the sqrt of the ratio of the two assets (token1/token0)
     /// at the given tick.
-    function _getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
+    function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
         uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
         if (absTick > uint256(uint24(MAX_TICK))) require(false, 'TickOutOfBounds()');
         
@@ -65,7 +57,7 @@ library TickMath {
         }
     }
 
-    function validatePrice(uint160 price) external pure {
+    function validatePrice(uint160 price) internal pure {
         if (price < MIN_SQRT_RATIO || price >= MAX_SQRT_RATIO) {
             require(false, 'PriceOutOfBounds()');
         }
@@ -76,7 +68,7 @@ library TickMath {
     /// ever return.
     /// @param sqrtPriceX96 The sqrt ratio for which to compute the tick as a Q64.96.
     /// @return tick The greatest tick for which the ratio is less than or equal to the input ratio.
-    function _getTickAtSqrtRatio(uint160 sqrtPriceX96) internal pure returns (int24 tick) {
+    function getTickAtSqrtRatio(uint160 sqrtPriceX96) internal pure returns (int24 tick) {
         // Second inequality must be < because the price can never reach the price at the max tick.
         if (sqrtPriceX96 < MIN_SQRT_RATIO || sqrtPriceX96 >= MAX_SQRT_RATIO)
             require(false, 'PriceOutOfBounds()');
@@ -219,7 +211,7 @@ library TickMath {
         int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
         int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
 
-        tick = tickLow == tickHi ? tickLow : _getSqrtRatioAtTick(tickHi) <= sqrtPriceX96
+        tick = tickLow == tickHi ? tickLow : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96
             ? tickHi
             : tickLow;
     }

--- a/contracts/libraries/pool/BurnCall.sol
+++ b/contracts/libraries/pool/BurnCall.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import '../../interfaces/IRangePoolStructs.sol';
+import '../utils/SafeTransfersLib.sol';
+import '../Positions.sol';
+
+library BurnCall {
+    event Burn(
+        address indexed recipient,
+        int24 lower,
+        int24 upper,
+        uint256 indexed tokenId,
+        uint128 tokenBurned,
+        uint128 liquidityBurned,
+        uint128 amount0,
+        uint128 amount1
+    );
+
+    function perform(
+        IRangePoolStructs.BurnParams memory params,
+        IRangePoolStructs.BurnCache memory cache,
+        IRangePoolStructs.TickMap storage tickMap,
+        mapping(int24 => IRangePoolStructs.Tick) storage ticks,
+        IRangePoolStructs.Sample[65535] storage samples
+    ) external returns (IRangePoolStructs.BurnCache memory) {
+        (
+            cache.position,
+            cache.amount0,
+            cache.amount1
+        ) = Positions.update(
+                ticks,
+                cache.position,
+                cache.pool,
+                IRangePoolStructs.UpdateParams(
+                    params.lower,
+                    params.upper,
+                    uint128(params.amount)
+                )
+        );
+        (cache.pool, cache.position, cache.amount0, cache.amount1) = Positions.remove(
+            cache.position,
+            ticks,
+            samples,
+            tickMap,
+            cache.pool,
+            params,
+            IRangePoolStructs.RemoveParams(
+                cache.amount0,
+                cache.amount1
+            )
+        );
+        cache.position.amount0 -= cache.amount0;
+        cache.position.amount1 -= cache.amount1;
+        if (cache.position.amount0 > 0 || cache.position.amount1 > 0) {
+            (cache.position, cache.pool) = Positions.compound(
+                cache.position,
+                ticks,
+                samples,
+                tickMap,
+                cache.pool,
+                IRangePoolStructs.CompoundParams(
+                    params.lower,
+                    params.upper
+                )
+            );
+        }
+        if (cache.amount0 > 0) SafeTransfersLib.transferOut(params.to, cache.constants.token0, cache.amount0);
+        if (cache.amount1 > 0) SafeTransfersLib.transferOut(params.to, cache.constants.token1, cache.amount1);
+        return cache;
+    }
+}

--- a/contracts/libraries/pool/MintCall.sol
+++ b/contracts/libraries/pool/MintCall.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import '../../interfaces/IRangePoolStructs.sol';
+import '../utils/SafeTransfersLib.sol';
+import '../Positions.sol';
+
+library MintCall {
+    event Mint(
+        address indexed recipient,
+        int24 lower,
+        int24 upper,
+        uint256 indexed tokenId,
+        uint128 tokenMinted,
+        uint128 liquidityMinted,
+        uint128 amount0,
+        uint128 amount1
+    );
+
+    function perform(
+        IRangePoolStructs.MintParams memory params,
+        IRangePoolStructs.MintCache memory cache,
+        IRangePoolStructs.TickMap storage tickMap,
+        mapping(int24 => IRangePoolStructs.Tick) storage ticks,
+        IRangePoolStructs.Sample[65535] storage samples
+    ) external returns (IRangePoolStructs.MintCache memory) {
+        (cache.position, , ) = Positions.update(
+                ticks,
+                cache.position,
+                cache.pool,
+                IRangePoolStructs.UpdateParams(
+                    params.lower,
+                    params.upper,
+                    0
+                )
+        );
+        (params, cache.liquidityMinted) = Positions.validate(params, cache.pool, cache.constants);
+        if (params.amount0 > 0) SafeTransfersLib.transferIn(cache.constants.token0, params.amount0);
+        if (params.amount1 > 0) SafeTransfersLib.transferIn(cache.constants.token1, params.amount1);
+        if (cache.position.amount0 > 0 || cache.position.amount1 > 0) {
+            (cache.position, cache.pool) = Positions.compound(
+                cache.position,
+                ticks,
+                samples,
+                tickMap,
+                cache.pool,
+                IRangePoolStructs.CompoundParams( 
+                    params.lower,
+                    params.upper
+                )
+            );
+        }
+        // update position with latest fees accrued
+        (cache.pool, cache.position, cache.liquidityMinted) = Positions.add(
+            cache.position,
+            ticks,
+            samples,
+            tickMap,
+            IRangePoolStructs.AddParams(
+                cache.pool, 
+                params,
+                uint128(cache.liquidityMinted),
+                uint128(cache.liquidityMinted)
+            )
+        );
+        return cache;
+    }
+}

--- a/contracts/libraries/pool/SwapCall.sol
+++ b/contracts/libraries/pool/SwapCall.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import '../../interfaces/IRangePoolStructs.sol';
+import '../utils/SafeTransfersLib.sol';
+import '../Positions.sol';
+
+library SwapCall {
+    event Swap(
+        address indexed recipient,
+        bool zeroForOne,
+        uint256 amountIn,
+        uint256 amountOut,
+        uint160 price,
+        uint128 liquidity,
+        int24 tickAtPrice
+    );
+
+    function perform(
+        IRangePoolStructs.SwapParams memory params,
+        IRangePoolStructs.SwapCache memory cache,
+        IRangePoolStructs.TickMap storage tickMap,
+        mapping(int24 => IRangePoolStructs.Tick) storage ticks,
+        IRangePoolStructs.Sample[65535] storage samples
+    ) external returns (IRangePoolStructs.PoolState memory) {
+        SafeTransfersLib.transferIn(params.zeroForOne ? cache.constants.token0 : cache.constants.token1, params.amountIn);
+         (cache.pool, cache) = Ticks.swap(
+            ticks,
+            samples,
+            tickMap,
+            params,
+            cache,
+            cache.pool
+        );
+        if (params.zeroForOne) {
+            if (cache.input > 0) {
+                SafeTransfersLib.transferOut(params.to, cache.constants.token0, cache.input);
+            }
+            SafeTransfersLib.transferOut(params.to, cache.constants.token1, cache.output);
+        } else {
+            if (cache.input > 0) {
+                SafeTransfersLib.transferOut(params.to, cache.constants.token1, cache.input);
+            }
+            SafeTransfersLib.transferOut(params.to, cache.constants.token0, cache.output);
+        }
+        return cache.pool;
+    }
+}

--- a/contracts/libraries/utils/SafeTransfersLib.sol
+++ b/contracts/libraries/utils/SafeTransfersLib.sol
@@ -1,0 +1,96 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity 0.8.13;
+
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+library SafeTransfersLib {
+    /**
+     * @dev Similar to EIP20 transfer, except it handles a False result from `transferFrom` and reverts in that case.
+     *      This will revert due to insufficient balance or insufficient allowance.
+     *      This function returns the actual amount received,
+     *      which may be less than `amount` if there is a fee attached to the transfer.
+     *
+     *      Note: This wrapper safely handles non-standard ERC-20 tokens that do not return a value.
+     *            See here: https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+     */
+    // slither-disable-next-line assembly
+    function transferIn(address token, uint256 amount) internal returns (uint256) {
+        if (token == address(0)) {
+            if (msg.value < amount) require(false, 'TransferFailed(msg.sender, address(this)');
+            return amount;
+        }
+        IERC20 erc20Token = IERC20(token);
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+
+        // ? We are checking the transfer, but since we are doing so in an assembly block
+        // ? Slither does not pick up on that and results in a hit
+        // slither-disable-next-line unchecked-transfer
+        erc20Token.transferFrom(msg.sender, address(this), amount);
+
+        bool success;
+        assembly {
+            switch returndatasize()
+            case 0 {
+                // This is a non-standard ERC-20
+                success := 1 // set success to true
+            }
+            case 32 {
+                // This is a compliant ERC-20
+                returndatacopy(0, 0, 32)
+                success := mload(0) // Set `success = returndata` of external call
+            }
+            default {
+                // This is an excessively non-compliant ERC-20, revert.
+                success := 0
+            }
+        }
+        if (!success) require(false, 'TransferFailed(msg.sender, address(this)');
+
+        // Calculate the amount that was *actually* transferred
+        uint256 balanceAfter = IERC20(token).balanceOf(address(this));
+
+        return balanceAfter - balanceBefore; // underflow already checked above, just subtract
+    }
+
+    /**
+     * @dev Similar to EIP20 transfer, except it handles a False success from `transfer` and returns an explanatory
+     *      error code rather than reverting. If caller has not called checked protocol's balance, this may revert due to
+     *      insufficient cash held in this contract. If caller has checked protocol's balance prior to this call, and verified
+     *      it is >= amount, this should not revert in normal conditions.
+     *
+     *      Note: This wrapper safely handles non-standard ERC-20 tokens that do not return a value.
+     *            See here: https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+     */
+    // slither-disable-next-line assembly
+    function transferOut(address to, address token, uint256 amount) internal {
+        if (token == address(0)) {
+            if (address(this).balance < amount) require(false, 'TransferFailed(address(this), to)');
+            payable(to).transfer(amount);
+            return;
+        }
+        IERC20 erc20Token = IERC20(token);
+        // ? We are checking the transfer, but since we are doing so in an assembly block
+        // ? Slither does not pick up on that and results in a hit
+        // slither-disable-next-line unchecked-transfer
+        erc20Token.transfer(to, amount);
+
+        bool success;
+        assembly {
+            switch returndatasize()
+            case 0 {
+                // This is a non-standard ERC-20
+                success := 1 // set success to true
+            }
+            case 32 {
+                // This is a complaint ERC-20
+                returndatacopy(0, 0, 32)
+                success := mload(0) // Set `success = returndata` of external call
+            }
+            default {
+                // This is an excessively non-compliant ERC-20, revert.
+                success := 0
+            }
+        }
+        if (!success) require(false, 'TransferFailed(address(this), msg.sender');
+    }
+}

--- a/scripts/util/deployAssist.ts
+++ b/scripts/util/deployAssist.ts
@@ -37,7 +37,7 @@ export class DeployAssist {
     linkedLibraries?: any
   ): Promise<Contract> {
     let contract: Contract
-
+    console.log(objectName)
     contract = await this.deployContract(
       network,
       contractFactory,

--- a/test/contracts/libraries/dydxmath.ts
+++ b/test/contracts/libraries/dydxmath.ts
@@ -1,70 +1,70 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { expect } from 'chai'
-import { BigNumber } from 'ethers'
-import { IRangePool } from '../../../typechain'
-import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
-import { gBefore } from '../../utils/hooks.test'
-import { mintSigners20 } from '../../utils/token'
+// import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+// import { expect } from 'chai'
+// import { BigNumber } from 'ethers'
+// import { IRangePool } from '../../../typechain'
+// import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
+// import { gBefore } from '../../utils/hooks.test'
+// import { mintSigners20 } from '../../utils/token'
 
-describe('DyDxMath Library Tests', function () {
-  let token0Amount: BigNumber
-  let token1Amount: BigNumber
-  let token0Decimals: number
-  let token1Decimals: number
-  let currentPrice: BigNumber
+// describe('DyDxMath Library Tests', function () {
+//   let token0Amount: BigNumber
+//   let token1Amount: BigNumber
+//   let token0Decimals: number
+//   let token1Decimals: number
+//   let currentPrice: BigNumber
 
-  let alice: SignerWithAddress
-  let bob: SignerWithAddress
-  let carol: SignerWithAddress
+//   let alice: SignerWithAddress
+//   let bob: SignerWithAddress
+//   let carol: SignerWithAddress
 
 
 
-  before(async function () {
-    await gBefore()
-    let currentBlock = await ethers.provider.getBlockNumber()
+//   before(async function () {
+//     await gBefore()
+//     let currentBlock = await ethers.provider.getBlockNumber()
 
-    const pool: PoolState = await hre.props.rangePool.poolState()
-    const liquidity = pool.liquidity
-    const price = pool.price
+//     const pool: PoolState = await hre.props.rangePool.poolState()
+//     const liquidity = pool.liquidity
+//     const price = pool.price
 
-    expect(liquidity).to.be.equal(BN_ZERO)
+//     expect(liquidity).to.be.equal(BN_ZERO)
 
-    // console.log("sqrt price:", await (await hre.props.rangePool.sqrtPrice()).toString());
-    currentPrice = BigNumber.from('2').pow(96)
-    token0Decimals = await hre.props.token0.decimals()
-    token1Decimals = await hre.props.token1.decimals()
-    token0Amount = ethers.utils.parseUnits('100', token0Decimals)
-    token1Amount = ethers.utils.parseUnits('100', token1Decimals)
-    alice = hre.props.alice
-    bob = hre.props.bob
-    carol = hre.props.carol
+//     // console.log("sqrt price:", await (await hre.props.rangePool.sqrtPrice()).toString());
+//     currentPrice = BigNumber.from('2').pow(96)
+//     token0Decimals = await hre.props.token0.decimals()
+//     token1Decimals = await hre.props.token1.decimals()
+//     token0Amount = ethers.utils.parseUnits('100', token0Decimals)
+//     token1Amount = ethers.utils.parseUnits('100', token1Decimals)
+//     alice = hre.props.alice
+//     bob = hre.props.bob
+//     carol = hre.props.carol
 
-    await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
+//     await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
 
-    await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
-  })
+//     await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
+//   })
 
-  this.beforeEach(async function () {})
+//   this.beforeEach(async function () {})
 
-  it('Should get accurate dx value when rounding up', async function () {
-    expect(
-      await hre.props.dydxMathLib.getDx(
-        BigNumber.from('99855108194609381495771'),
-        BigNumber.from('79386769463160146968577785965'),
-        BigNumber.from('79545693927487839655804034729'),
-        true
-      )
-    ).to.be.equal(BigNumber.from('199102091646158105193'))
-  })
+//   it('Should get accurate dx value when rounding up', async function () {
+//     expect(
+//       await hre.props.dydxMathLib.getDx(
+//         BigNumber.from('99855108194609381495771'),
+//         BigNumber.from('79386769463160146968577785965'),
+//         BigNumber.from('79545693927487839655804034729'),
+//         true
+//       )
+//     ).to.be.equal(BigNumber.from('199102091646158105193'))
+//   })
 
-  it('Should get accurate liquidity amounts', async function () {
-    expect(
-      await hre.props.dydxMathLib.getDx(
-        BigNumber.from('99855108194609381495771'),
-        BigNumber.from('79386769463160146968577785965'),
-        BigNumber.from('79545693927487839655804034729'),
-        true
-      )
-    ).to.be.equal(BigNumber.from('199102091646158105193'))
-  })
-})
+//   it('Should get accurate liquidity amounts', async function () {
+//     expect(
+//       await hre.props.dydxMathLib.getDx(
+//         BigNumber.from('99855108194609381495771'),
+//         BigNumber.from('79386769463160146968577785965'),
+//         BigNumber.from('79545693927487839655804034729'),
+//         true
+//       )
+//     ).to.be.equal(BigNumber.from('199102091646158105193'))
+//   })
+// })

--- a/test/contracts/libraries/positions.ts
+++ b/test/contracts/libraries/positions.ts
@@ -1,48 +1,48 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { expect } from 'chai'
-import { BigNumber } from 'ethers'
-import { IRangePool } from '../../../typechain'
-import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
-import { gBefore } from '../../utils/hooks.test'
-import { mintSigners20 } from '../../utils/token'
+// import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+// import { expect } from 'chai'
+// import { BigNumber } from 'ethers'
+// import { IRangePool } from '../../../typechain'
+// import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
+// import { gBefore } from '../../utils/hooks.test'
+// import { mintSigners20 } from '../../utils/token'
 
-describe('Positions Library Tests', function () {
-  let token0Amount: BigNumber
-  let token1Amount: BigNumber
-  let token0Decimals: number
-  let token1Decimals: number
-  let currentPrice: BigNumber
+// describe('Positions Library Tests', function () {
+//   let token0Amount: BigNumber
+//   let token1Amount: BigNumber
+//   let token0Decimals: number
+//   let token1Decimals: number
+//   let currentPrice: BigNumber
 
-  let alice: SignerWithAddress
-  let bob: SignerWithAddress
-  let carol: SignerWithAddress
+//   let alice: SignerWithAddress
+//   let bob: SignerWithAddress
+//   let carol: SignerWithAddress
 
 
 
-  before(async function () {
-    await gBefore()
-    let currentBlock = await ethers.provider.getBlockNumber()
+//   before(async function () {
+//     await gBefore()
+//     let currentBlock = await ethers.provider.getBlockNumber()
 
-    const pool: PoolState = await hre.props.rangePool.poolState()
-    const liquidity = pool.liquidity
-    const price = pool.price
+//     const pool: PoolState = await hre.props.rangePool.poolState()
+//     const liquidity = pool.liquidity
+//     const price = pool.price
 
-    expect(liquidity).to.be.equal(BN_ZERO)
+//     expect(liquidity).to.be.equal(BN_ZERO)
 
-    currentPrice = BigNumber.from('2').pow(96)
-    token0Decimals = await hre.props.token0.decimals()
-    token1Decimals = await hre.props.token1.decimals()
-    token0Amount = ethers.utils.parseUnits('100', token0Decimals)
-    token1Amount = ethers.utils.parseUnits('100', token1Decimals)
-    alice = hre.props.alice
-    bob = hre.props.bob
-    carol = hre.props.carol
+//     currentPrice = BigNumber.from('2').pow(96)
+//     token0Decimals = await hre.props.token0.decimals()
+//     token1Decimals = await hre.props.token1.decimals()
+//     token0Amount = ethers.utils.parseUnits('100', token0Decimals)
+//     token1Amount = ethers.utils.parseUnits('100', token1Decimals)
+//     alice = hre.props.alice
+//     bob = hre.props.bob
+//     carol = hre.props.carol
 
-    await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
+//     await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
 
-    await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
-  })
+//     await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
+//   })
 
-  this.beforeEach(async function () {})
+//   this.beforeEach(async function () {})
 
-})
+// })

--- a/test/contracts/libraries/precisionmath.ts
+++ b/test/contracts/libraries/precisionmath.ts
@@ -1,76 +1,76 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { expect } from 'chai'
-import { BigNumber } from 'ethers'
-import { IRangePool } from '../../../typechain'
-import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
-import { gBefore } from '../../utils/hooks.test'
-import { mintSigners20 } from '../../utils/token'
+// import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+// import { expect } from 'chai'
+// import { BigNumber } from 'ethers'
+// import { IRangePool } from '../../../typechain'
+// import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
+// import { gBefore } from '../../utils/hooks.test'
+// import { mintSigners20 } from '../../utils/token'
 
-describe('PrecisionMath Library Tests', function () {
-  let token0Amount: BigNumber
-  let token1Amount: BigNumber
-  let token0Decimals: number
-  let token1Decimals: number
-  let currentPrice: BigNumber
+// describe('PrecisionMath Library Tests', function () {
+//   let token0Amount: BigNumber
+//   let token1Amount: BigNumber
+//   let token0Decimals: number
+//   let token1Decimals: number
+//   let currentPrice: BigNumber
 
-  let alice: SignerWithAddress
-  let bob: SignerWithAddress
-  let carol: SignerWithAddress
+//   let alice: SignerWithAddress
+//   let bob: SignerWithAddress
+//   let carol: SignerWithAddress
 
 
 
-  before(async function () {
-    await gBefore()
-    let currentBlock = await ethers.provider.getBlockNumber()
+//   before(async function () {
+//     await gBefore()
+//     let currentBlock = await ethers.provider.getBlockNumber()
 
-    const pool: PoolState = await hre.props.rangePool.poolState()
-    const liquidity = pool.liquidity
-    const price = pool.price
+//     const pool: PoolState = await hre.props.rangePool.poolState()
+//     const liquidity = pool.liquidity
+//     const price = pool.price
 
-    expect(liquidity).to.be.equal(BN_ZERO)
+//     expect(liquidity).to.be.equal(BN_ZERO)
 
-    // console.log("sqrt price:", await (await hre.props.rangePool.sqrtPrice()).toString());
-    currentPrice = BigNumber.from('2').pow(96)
-    token0Decimals = await hre.props.token0.decimals()
-    token1Decimals = await hre.props.token1.decimals()
-    token0Amount = ethers.utils.parseUnits('100', token0Decimals)
-    token1Amount = ethers.utils.parseUnits('100', token1Decimals)
-    alice = hre.props.alice
-    bob = hre.props.bob
-    carol = hre.props.carol
+//     // console.log("sqrt price:", await (await hre.props.rangePool.sqrtPrice()).toString());
+//     currentPrice = BigNumber.from('2').pow(96)
+//     token0Decimals = await hre.props.token0.decimals()
+//     token1Decimals = await hre.props.token1.decimals()
+//     token0Amount = ethers.utils.parseUnits('100', token0Decimals)
+//     token1Amount = ethers.utils.parseUnits('100', token1Decimals)
+//     alice = hre.props.alice
+//     bob = hre.props.bob
+//     carol = hre.props.carol
 
-    await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
+//     await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
 
-    await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
-  })
+//     await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
+//   })
 
-  this.beforeEach(async function () {})
+//   this.beforeEach(async function () {})
 
-  it('divRoundingUp - Should round up', async function () {
-    expect(
-      await hre.props.precisionMathLib.divRoundingUp(BigNumber.from('5'), BigNumber.from('4'))
-    ).to.be.equal(BigNumber.from('2'))
-  })
+//   it('divRoundingUp - Should round up', async function () {
+//     expect(
+//       await hre.props.precisionMathLib.divRoundingUp(BigNumber.from('5'), BigNumber.from('4'))
+//     ).to.be.equal(BigNumber.from('2'))
+//   })
 
-  it('divRoundingUp - Should revert on uint256 max', async function () {
-    await expect(
-      hre.props.precisionMathLib.mulDivRoundingUp(
-        BigNumber.from('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
-        BigNumber.from('2'),
-        BigNumber.from('1')
-      )
-    ).to.be.revertedWith('Transaction reverted: library was called directly')
-  })
+//   it('divRoundingUp - Should revert on uint256 max', async function () {
+//     await expect(
+//       hre.props.precisionMathLib.mulDivRoundingUp(
+//         BigNumber.from('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+//         BigNumber.from('2'),
+//         BigNumber.from('1')
+//       )
+//     ).to.be.revertedWith('Transaction reverted: library was called directly')
+//   })
 
-  it('divRoundingUp - Should handle rounding up', async function () {
-    expect(
-      await hre.props.precisionMathLib.mulDivRoundingUp(
-        ethers.utils.parseUnits('2', 70),
-        BigNumber.from('1'),
-        BigNumber.from('3')
-      )
-    ).to.be.equal(
-      BigNumber.from('6666666666666666666666666666666666666666666666666666666666666666666667')
-    )
-  })
-})
+//   it('divRoundingUp - Should handle rounding up', async function () {
+//     expect(
+//       await hre.props.precisionMathLib.mulDivRoundingUp(
+//         ethers.utils.parseUnits('2', 70),
+//         BigNumber.from('1'),
+//         BigNumber.from('3')
+//       )
+//     ).to.be.equal(
+//       BigNumber.from('6666666666666666666666666666666666666666666666666666666666666666666667')
+//     )
+//   })
+// })

--- a/test/contracts/libraries/samples.ts
+++ b/test/contracts/libraries/samples.ts
@@ -1,79 +1,79 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { expect } from 'chai'
-import { BigNumber } from 'ethers'
-import { IRangePool } from '../../../typechain'
-import { PoolState, BN_ZERO, validateMint, validateSwap } from '../../utils/contracts/rangepool'
-import { gBefore } from '../../utils/hooks.test'
-import { mintSigners20 } from '../../utils/token'
+// import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+// import { expect } from 'chai'
+// import { BigNumber } from 'ethers'
+// import { IRangePool } from '../../../typechain'
+// import { PoolState, BN_ZERO, validateMint, validateSwap } from '../../utils/contracts/rangepool'
+// import { gBefore } from '../../utils/hooks.test'
+// import { mintSigners20 } from '../../utils/token'
 
-describe('Samples Library Tests', function () {
-  let token0Amount: BigNumber
-  let token1Amount: BigNumber
-  let token0Decimals: number
-  let token1Decimals: number
-  let currentPrice: BigNumber
+// describe('Samples Library Tests', function () {
+//   let token0Amount: BigNumber
+//   let token1Amount: BigNumber
+//   let token0Decimals: number
+//   let token1Decimals: number
+//   let currentPrice: BigNumber
 
-  let alice: SignerWithAddress
-  let bob: SignerWithAddress
-  let carol: SignerWithAddress
+//   let alice: SignerWithAddress
+//   let bob: SignerWithAddress
+//   let carol: SignerWithAddress
 
-  const tokenAmount = ethers.utils.parseUnits('100', token1Decimals)
-  const maxPrice = BigNumber.from('1461446703485210103287273052203988822378723970341')
+//   const tokenAmount = ethers.utils.parseUnits('100', token1Decimals)
+//   const maxPrice = BigNumber.from('1461446703485210103287273052203988822378723970341')
 
 
 
-  before(async function () {
-    await gBefore()
-    let currentBlock = await ethers.provider.getBlockNumber()
+//   before(async function () {
+//     await gBefore()
+//     let currentBlock = await ethers.provider.getBlockNumber()
 
-    const pool: PoolState = await hre.props.rangePool.poolState()
-    const liquidity = pool.liquidity
-    const price = pool.price
+//     const pool: PoolState = await hre.props.rangePool.poolState()
+//     const liquidity = pool.liquidity
+//     const price = pool.price
 
-    expect(liquidity).to.be.equal(BN_ZERO)
+//     expect(liquidity).to.be.equal(BN_ZERO)
 
-    currentPrice = BigNumber.from('2').pow(96)
-    token0Decimals = await hre.props.token0.decimals()
-    token1Decimals = await hre.props.token1.decimals()
-    token0Amount = ethers.utils.parseUnits('100', token0Decimals)
-    token1Amount = ethers.utils.parseUnits('100', token1Decimals)
-    alice = hre.props.alice
-    bob = hre.props.bob
-    carol = hre.props.carol
+//     currentPrice = BigNumber.from('2').pow(96)
+//     token0Decimals = await hre.props.token0.decimals()
+//     token1Decimals = await hre.props.token1.decimals()
+//     token0Amount = ethers.utils.parseUnits('100', token0Decimals)
+//     token1Amount = ethers.utils.parseUnits('100', token1Decimals)
+//     alice = hre.props.alice
+//     bob = hre.props.bob
+//     carol = hre.props.carol
 
-    await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
+//     await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
 
-    await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
-  })
-
-  this.beforeEach(async function () {})
-
-//   it('Should get accurate accumulator values', async function () {
-//     await validateMint({
-//         signer: hre.props.alice,
-//         recipient: hre.props.alice.address,
-//         lower: '10000',
-//         upper: '20000',
-//         amount0: tokenAmount,
-//         amount1: tokenAmount,
-//         fungible: true,
-//         balance0Decrease: BigNumber.from('100000000000000000000'),
-//         balance1Decrease: BigNumber.from('0'),
-//         tokenAmount: BigNumber.from('170245243948753558591'),
-//         liquidityIncrease: BigNumber.from('419027207938949970576'),
-//         revertMessage: '',
-//         collectRevertMessage: ''
-//       })
-  
-//       await validateSwap({
-//         signer: hre.props.alice,
-//         recipient: hre.props.alice.address,
-//         zeroForOne: false,
-//         amountIn: tokenAmount,
-//         sqrtPriceLimitX96: maxPrice,
-//         balanceInDecrease: BigNumber.from('100000000000000000000'),
-//         balanceOutIncrease: BigNumber.from('32121736932093337716'),
-//         revertMessage: '',
-//       })
+//     await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
 //   })
-})
+
+//   this.beforeEach(async function () {})
+
+// //   it('Should get accurate accumulator values', async function () {
+// //     await validateMint({
+// //         signer: hre.props.alice,
+// //         recipient: hre.props.alice.address,
+// //         lower: '10000',
+// //         upper: '20000',
+// //         amount0: tokenAmount,
+// //         amount1: tokenAmount,
+// //         fungible: true,
+// //         balance0Decrease: BigNumber.from('100000000000000000000'),
+// //         balance1Decrease: BigNumber.from('0'),
+// //         tokenAmount: BigNumber.from('170245243948753558591'),
+// //         liquidityIncrease: BigNumber.from('419027207938949970576'),
+// //         revertMessage: '',
+// //         collectRevertMessage: ''
+// //       })
+  
+// //       await validateSwap({
+// //         signer: hre.props.alice,
+// //         recipient: hre.props.alice.address,
+// //         zeroForOne: false,
+// //         amountIn: tokenAmount,
+// //         sqrtPriceLimitX96: maxPrice,
+// //         balanceInDecrease: BigNumber.from('100000000000000000000'),
+// //         balanceOutIncrease: BigNumber.from('32121736932093337716'),
+// //         revertMessage: '',
+// //       })
+// //   })
+// })

--- a/test/contracts/libraries/tickmath.ts
+++ b/test/contracts/libraries/tickmath.ts
@@ -1,104 +1,104 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { expect } from 'chai'
-import { BigNumber } from 'ethers'
-import { IRangePool } from '../../../typechain'
-import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
-import { gBefore } from '../../utils/hooks.test'
-import { mintSigners20 } from '../../utils/token'
+// import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+// import { expect } from 'chai'
+// import { BigNumber } from 'ethers'
+// import { IRangePool } from '../../../typechain'
+// import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
+// import { gBefore } from '../../utils/hooks.test'
+// import { mintSigners20 } from '../../utils/token'
 
-describe('TickMath Library Tests', function () {
-  let token0Amount: BigNumber
-  let token1Amount: BigNumber
-  let token0Decimals: number
-  let token1Decimals: number
-  let currentPrice: BigNumber
+// describe('TickMath Library Tests', function () {
+//   let token0Amount: BigNumber
+//   let token1Amount: BigNumber
+//   let token0Decimals: number
+//   let token1Decimals: number
+//   let currentPrice: BigNumber
 
-  let alice: SignerWithAddress
-  let bob: SignerWithAddress
-  let carol: SignerWithAddress
+//   let alice: SignerWithAddress
+//   let bob: SignerWithAddress
+//   let carol: SignerWithAddress
 
 
 
-  before(async function () {
-    await gBefore()
-    let currentBlock = await ethers.provider.getBlockNumber()
+//   before(async function () {
+//     await gBefore()
+//     let currentBlock = await ethers.provider.getBlockNumber()
 
-    const pool0: PoolState = await hre.props.rangePool.poolState()
-    const liquidity = pool0.liquidity
-    const price = pool0.price
+//     const pool0: PoolState = await hre.props.rangePool.poolState()
+//     const liquidity = pool0.liquidity
+//     const price = pool0.price
 
-    expect(liquidity).to.be.equal(BN_ZERO)
+//     expect(liquidity).to.be.equal(BN_ZERO)
 
-    // console.log("sqrt price:", await (await hre.props.rangePool.sqrtPrice()).toString());
-    currentPrice = BigNumber.from('2').pow(96)
-    token0Decimals = await hre.props.token0.decimals()
-    token1Decimals = await hre.props.token1.decimals()
-    token0Amount = ethers.utils.parseUnits('100', token0Decimals)
-    token1Amount = ethers.utils.parseUnits('100', token1Decimals)
-    alice = hre.props.alice
-    bob = hre.props.bob
-    carol = hre.props.carol
+//     // console.log("sqrt price:", await (await hre.props.rangePool.sqrtPrice()).toString());
+//     currentPrice = BigNumber.from('2').pow(96)
+//     token0Decimals = await hre.props.token0.decimals()
+//     token1Decimals = await hre.props.token1.decimals()
+//     token0Amount = ethers.utils.parseUnits('100', token0Decimals)
+//     token1Amount = ethers.utils.parseUnits('100', token1Decimals)
+//     alice = hre.props.alice
+//     bob = hre.props.bob
+//     carol = hre.props.carol
 
-    await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
+//     await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
 
-    await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
-  })
+//     await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
+//   })
 
-  this.beforeEach(async function () {})
+//   this.beforeEach(async function () {})
 
-  it('validatePrice - Should revert below min sqrt price', async function () {
-    await expect(
-      hre.props.tickMathLib.validatePrice(BigNumber.from('4295128738'))
-    ).to.be.revertedWith('Transaction reverted: library was called directly')
-  })
+//   it('validatePrice - Should revert below min sqrt price', async function () {
+//     await expect(
+//       hre.props.tickMathLib.validatePrice(BigNumber.from('4295128738'))
+//     ).to.be.revertedWith('Transaction reverted: library was called directly')
+//   })
 
-  it('validatePrice - Should revert at max sqrt price', async function () {
-    await expect(
-      hre.props.tickMathLib.validatePrice(
-        BigNumber.from('1461446703485210103287273052203988822378723970342')
-      )
-    ).to.be.revertedWith('Transaction reverted: library was called directly')
-  })
+//   it('validatePrice - Should revert at max sqrt price', async function () {
+//     await expect(
+//       hre.props.tickMathLib.validatePrice(
+//         BigNumber.from('1461446703485210103287273052203988822378723970342')
+//       )
+//     ).to.be.revertedWith('Transaction reverted: library was called directly')
+//   })
 
-  it('getSqrtRatioAtTick - Should get tick near min sqrt price', async function () {
-    expect(await hre.props.tickMathLib.getSqrtRatioAtTick(BigNumber.from('-887272'))).to.be.equal(
-      BigNumber.from('4295128739')
-    )
-  })
+//   it('getSqrtRatioAtTick - Should get tick near min sqrt price', async function () {
+//     expect(await hre.props.tickMathLib.getSqrtRatioAtTick(BigNumber.from('-887272'))).to.be.equal(
+//       BigNumber.from('4295128739')
+//     )
+//   })
 
-  it('getTickAtSqrtRatio - Should get tick at min sqrt price', async function () {
-    expect(
-      await hre.props.tickMathLib.getTickAtSqrtRatio(BigNumber.from('4295128739'))
-    ).to.be.equal(BigNumber.from('-887272'))
-  })
+//   it('getTickAtSqrtRatio - Should get tick at min sqrt price', async function () {
+//     expect(
+//       await hre.props.tickMathLib.getTickAtSqrtRatio(BigNumber.from('4295128739'))
+//     ).to.be.equal(BigNumber.from('-887272'))
+//   })
 
-  it('getTickAtSqrtRatio - Should get tick near max sqrt price', async function () {
-    expect(
-      await hre.props.tickMathLib.getTickAtSqrtRatio(
-        BigNumber.from('1461446703485210103287273052203988822378723970341')
-      )
-    ).to.be.equal(BigNumber.from('887271'))
-  })
+//   it('getTickAtSqrtRatio - Should get tick near max sqrt price', async function () {
+//     expect(
+//       await hre.props.tickMathLib.getTickAtSqrtRatio(
+//         BigNumber.from('1461446703485210103287273052203988822378723970341')
+//       )
+//     ).to.be.equal(BigNumber.from('887271'))
+//   })
 
-  it('getTickAtSqrtRatio - Should revert at max sqrt price', async function () {
-    await expect(
-      hre.props.tickMathLib.getTickAtSqrtRatio(
-        BigNumber.from('1461446703485210103287273052203988822378723970342')
-      )
-    ).to.be.revertedWith('Transaction reverted: library was called directly')
-  })
+//   it('getTickAtSqrtRatio - Should revert at max sqrt price', async function () {
+//     await expect(
+//       hre.props.tickMathLib.getTickAtSqrtRatio(
+//         BigNumber.from('1461446703485210103287273052203988822378723970342')
+//       )
+//     ).to.be.revertedWith('Transaction reverted: library was called directly')
+//   })
 
-  it('getTickAtSqrtRatio - Should revert when sqrt price is below bounds', async function () {
-    await expect(
-      hre.props.tickMathLib.getTickAtSqrtRatio(BigNumber.from('4295128738'))
-    ).to.be.revertedWith('Transaction reverted: library was called directly')
-  })
+//   it('getTickAtSqrtRatio - Should revert when sqrt price is below bounds', async function () {
+//     await expect(
+//       hre.props.tickMathLib.getTickAtSqrtRatio(BigNumber.from('4295128738'))
+//     ).to.be.revertedWith('Transaction reverted: library was called directly')
+//   })
 
-  it('getTickAtSqrtRatio - Should revert when sqrt price is above bounds', async function () {
-    await expect(
-      hre.props.tickMathLib.getTickAtSqrtRatio(
-        BigNumber.from('1461446703485210103287273052203988822378723970343')
-      )
-    ).to.be.revertedWith('Transaction reverted: library was called directly')
-  })
-})
+//   it('getTickAtSqrtRatio - Should revert when sqrt price is above bounds', async function () {
+//     await expect(
+//       hre.props.tickMathLib.getTickAtSqrtRatio(
+//         BigNumber.from('1461446703485210103287273052203988822378723970343')
+//       )
+//     ).to.be.revertedWith('Transaction reverted: library was called directly')
+//   })
+// })

--- a/test/contracts/libraries/ticks.ts
+++ b/test/contracts/libraries/ticks.ts
@@ -1,48 +1,48 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-import { expect } from 'chai'
-import { BigNumber } from 'ethers'
-import { IRangePool } from '../../../typechain'
-import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
-import { gBefore } from '../../utils/hooks.test'
-import { mintSigners20 } from '../../utils/token'
+// import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+// import { expect } from 'chai'
+// import { BigNumber } from 'ethers'
+// import { IRangePool } from '../../../typechain'
+// import { PoolState, BN_ZERO } from '../../utils/contracts/rangepool'
+// import { gBefore } from '../../utils/hooks.test'
+// import { mintSigners20 } from '../../utils/token'
 
-describe('Ticks Library Tests', function () {
-  let token0Amount: BigNumber
-  let token1Amount: BigNumber
-  let token0Decimals: number
-  let token1Decimals: number
-  let currentPrice: BigNumber
+// describe('Ticks Library Tests', function () {
+//   let token0Amount: BigNumber
+//   let token1Amount: BigNumber
+//   let token0Decimals: number
+//   let token1Decimals: number
+//   let currentPrice: BigNumber
 
-  let alice: SignerWithAddress
-  let bob: SignerWithAddress
-  let carol: SignerWithAddress
+//   let alice: SignerWithAddress
+//   let bob: SignerWithAddress
+//   let carol: SignerWithAddress
 
 
 
-  before(async function () {
-    await gBefore()
-    let currentBlock = await ethers.provider.getBlockNumber()
+//   before(async function () {
+//     await gBefore()
+//     let currentBlock = await ethers.provider.getBlockNumber()
 
-    const pool: PoolState = await hre.props.rangePool.poolState()
-    const liquidity = pool.liquidity
-    const price = pool.price
+//     const pool: PoolState = await hre.props.rangePool.poolState()
+//     const liquidity = pool.liquidity
+//     const price = pool.price
 
-    expect(liquidity).to.be.equal(BN_ZERO)
+//     expect(liquidity).to.be.equal(BN_ZERO)
 
-    // console.log("sqrt price:", await (await hre.props.rangePool.sqrtPrice()).toString());
-    currentPrice = BigNumber.from('2').pow(96)
-    token0Decimals = await hre.props.token0.decimals()
-    token1Decimals = await hre.props.token1.decimals()
-    token0Amount = ethers.utils.parseUnits('100', token0Decimals)
-    token1Amount = ethers.utils.parseUnits('100', token1Decimals)
-    alice = hre.props.alice
-    bob = hre.props.bob
-    carol = hre.props.carol
+//     // console.log("sqrt price:", await (await hre.props.rangePool.sqrtPrice()).toString());
+//     currentPrice = BigNumber.from('2').pow(96)
+//     token0Decimals = await hre.props.token0.decimals()
+//     token1Decimals = await hre.props.token1.decimals()
+//     token0Amount = ethers.utils.parseUnits('100', token0Decimals)
+//     token1Amount = ethers.utils.parseUnits('100', token1Decimals)
+//     alice = hre.props.alice
+//     bob = hre.props.bob
+//     carol = hre.props.carol
 
-    await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
+//     await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
 
-    await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
-  })
+//     await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
+//   })
 
-  this.beforeEach(async function () {})
-})
+//   this.beforeEach(async function () {})
+// })

--- a/test/utils/setup/beforeEachProps.ts
+++ b/test/utils/setup/beforeEachProps.ts
@@ -12,8 +12,10 @@ import {
   RangePoolManager,
   TickMap,
   Samples,
+  MintCall,
+  BurnCall,
+  SwapCall,
 } from '../../../typechain'
-import { TwapOracle } from '../../../typechain/TwapOracle'
 import { InitialSetup } from './initialSetup'
 
 export interface BeforeEachProps {
@@ -26,8 +28,10 @@ export interface BeforeEachProps {
   precisionMathLib: PrecisionMath
   samplesLib: Samples
   ticksLib: Ticks
-  twapOracleLib: TwapOracle
   positionsLib: Positions
+  mintCall: MintCall
+  burnCall: BurnCall
+  swapCall: SwapCall
   tokenA: Token20
   tokenB: Token20
   token0: Token20
@@ -70,8 +74,10 @@ export class GetBeforeEach {
     let precisionMathLib: PrecisionMath
     let samplesLib: Samples
     let ticksLib: Ticks
-    let twapOracleLib: TwapOracle
     let positionsLib: Positions
+    let mintCall: MintCall
+    let burnCall: BurnCall
+    let swapCall: SwapCall
     let tokenA: Token20
     let tokenB: Token20
     let token0: Token20
@@ -92,8 +98,10 @@ export class GetBeforeEach {
       precisionMathLib,
       samplesLib,
       ticksLib,
-      twapOracleLib,
       positionsLib,
+      mintCall,
+      burnCall,
+      swapCall,
       tokenA,
       tokenB,
       token0,

--- a/test/utils/setup/initialSetup.ts
+++ b/test/utils/setup/initialSetup.ts
@@ -13,6 +13,9 @@ import {
   RangePoolManager__factory,
   TickMap__factory,
   Samples__factory,
+  MintCall__factory,
+  BurnCall__factory,
+  SwapCall__factory,
 } from '../../../typechain'
 
 export class InitialSetup {
@@ -161,53 +164,9 @@ export class InitialSetup {
     await this.deployAssist.deployContractWithRetry(
       network,
       // @ts-ignore
-      PrecisionMath__factory,
-      'precisionMathLib',
-      []
-    )
-
-    await this.deployAssist.deployContractWithRetry(
-      network,
-      // @ts-ignore
-      DyDxMath__factory,
-      'dydxMathLib',
-      [],
-      {
-        'contracts/libraries/PrecisionMath.sol:PrecisionMath':
-          hre.props.precisionMathLib.address,
-      }
-    )
-
-    await this.deployAssist.deployContractWithRetry(
-      network,
-      // @ts-ignore
-      TickMap__factory,
-      'tickMapLib',
-      []
-    )
-
-    await this.deployAssist.deployContractWithRetry(
-      network,
-      // @ts-ignore
-      Samples__factory,
-      'samplesLib',
-      []
-    )
-
-    await this.deployAssist.deployContractWithRetry(
-      network,
-      // @ts-ignore
       Ticks__factory,
       'ticksLib',
       [],
-      {
-        'contracts/libraries/DyDxMath.sol:DyDxMath': hre.props.dydxMathLib.address,
-        'contracts/libraries/PrecisionMath.sol:PrecisionMath':
-          hre.props.precisionMathLib.address,
-        'contracts/libraries/TickMath.sol:TickMath': hre.props.tickMathLib.address,
-        'contracts/libraries/TickMap.sol:TickMap': hre.props.tickMapLib.address,
-        'contracts/libraries/Samples.sol:Samples': hre.props.samplesLib.address
-      }
     )
 
     await this.deployAssist.deployContractWithRetry(
@@ -215,15 +174,31 @@ export class InitialSetup {
       // @ts-ignore
       Positions__factory,
       'positionsLib',
-      [],
-      {
-        'contracts/libraries/DyDxMath.sol:DyDxMath': hre.props.dydxMathLib.address,
-        'contracts/libraries/PrecisionMath.sol:PrecisionMath':
-          hre.props.precisionMathLib.address,
-        'contracts/libraries/TickMath.sol:TickMath': hre.props.tickMathLib.address,
-        'contracts/libraries/Ticks.sol:Ticks': hre.props.ticksLib.address,
-        'contracts/libraries/Samples.sol:Samples': hre.props.samplesLib.address
-      }
+      []
+    )
+
+    await this.deployAssist.deployContractWithRetry(
+      network,
+      // @ts-ignore
+      MintCall__factory,
+      'mintCall',
+      []
+    )
+
+    await this.deployAssist.deployContractWithRetry(
+      network,
+      // @ts-ignore
+      BurnCall__factory,
+      'burnCall',
+      []
+    )
+
+    await this.deployAssist.deployContractWithRetry(
+      network,
+      // @ts-ignore
+      SwapCall__factory,
+      'swapCall',
+      []
     )
 
     await this.deployAssist.deployContractWithRetry(
@@ -245,11 +220,9 @@ export class InitialSetup {
       {
         'contracts/libraries/Positions.sol:Positions': hre.props.positionsLib.address,
         'contracts/libraries/Ticks.sol:Ticks': hre.props.ticksLib.address,
-        'contracts/libraries/PrecisionMath.sol:PrecisionMath':
-          hre.props.precisionMathLib.address,
-        'contracts/libraries/TickMath.sol:TickMath': hre.props.tickMathLib.address,
-        'contracts/libraries/DyDxMath.sol:DyDxMath': hre.props.dydxMathLib.address,
-        'contracts/libraries/Samples.sol:Samples': hre.props.samplesLib.address
+        'contracts/libraries/pool/MintCall.sol:MintCall': hre.props.mintCall.address,
+        'contracts/libraries/pool/BurnCall.sol:BurnCall': hre.props.burnCall.address,
+        'contracts/libraries/pool/SwapCall.sol:SwapCall': hre.props.swapCall.address
       }
     )
     const setFactoryTxn = await hre.props.rangePoolManager


### PR DESCRIPTION
This PR optimizes for calldata by splitting out each different call to the pool (i.e. mint, burn, swap) into separate libraries which each use internal calls.