### PR TITLE
Return average values for sample period

### DIFF
--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -154,7 +154,10 @@ contract RangePool is
         uint32[] memory secondsAgo
     ) external view override returns(
         int56[]   memory tickSecondsAccum,
-        uint160[] memory secondsPerLiquidityAccum
+        uint160[] memory secondsPerLiquidityAccum,
+        uint160 averagePrice,
+        uint128 averageLiquidity,
+        int24 averageTick
     ) {
         return SampleCall.perform(poolState, secondsAgo);
     }

--- a/contracts/RangePool.sol
+++ b/contracts/RangePool.sol
@@ -167,7 +167,6 @@ contract RangePool is
     ) external view override returns (
         int56   tickSecondsAccum,
         uint160 secondsPerLiquidityAccum,
-        uint32  secondsGrowth,
         uint128 feesOwed0,
         uint128 feesOwed1
     ) {

--- a/contracts/interfaces/IRangePool.sol
+++ b/contracts/interfaces/IRangePool.sol
@@ -32,7 +32,10 @@ interface IRangePool is IRangePoolStructs {
         uint32[] memory secondsAgo
     ) external view returns (
         int56[]   memory tickSecondsAccum,
-        uint160[] memory secondsPerLiquidityAccum 
+        uint160[] memory secondsPerLiquidityAccum,
+        uint160 averagePrice,
+        uint128 averageLiquidity,
+        int24 averageTick
     );
 
     function snapshot(

--- a/contracts/interfaces/IRangePool.sol
+++ b/contracts/interfaces/IRangePool.sol
@@ -43,7 +43,6 @@ interface IRangePool is IRangePoolStructs {
     ) external view returns(
         int56   tickSecondsAccum,
         uint160 secondsPerLiquidityAccum,
-        uint32  secondsGrowth,
         uint128 feesOwed0,
         uint128 feesOwed1
     );

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -400,28 +400,21 @@ library Positions {
             uint256 _feeGrowthGlobal1,
             ,
         ) = IRangePool(pool).poolState();
+
         (
             ,
-            uint216 tickLowerFeeGrowthOutside0,
-            uint216 tickLowerFeeGrowthOutside1,
+            uint200 tickLowerFeeGrowthOutside0,
+            uint200 tickLowerFeeGrowthOutside1,
             ,
         )
             = IRangePool(pool).ticks(lower);
         (
             ,
-            uint216 tickUpperFeeGrowthOutside0,
-            uint216 tickUpperFeeGrowthOutside1,
+            uint200 tickUpperFeeGrowthOutside0,
+            uint200 tickUpperFeeGrowthOutside1,
             ,
         )
             = IRangePool(pool).ticks(upper);
-
-        // ticks not initialized or range not crossed into
-        if (tickLowerFeeGrowthOutside0 == 0
-            && tickLowerFeeGrowthOutside1 == 0
-            && tickUpperFeeGrowthOutside0 == 0
-            && tickUpperFeeGrowthOutside0 == 0) {
-            return (0,0);
-        }
 
         uint256 feeGrowthBelow0;
         uint256 feeGrowthBelow1;
@@ -455,7 +448,6 @@ library Positions {
     ) external view returns (
         int56   tickSecondsAccum,
         uint160 secondsPerLiquidityAccum,
-        uint32  secondsGrowth,
         uint128 feesOwed0,
         uint128 feesOwed1
     ) {
@@ -518,13 +510,9 @@ library Positions {
             )
         );
 
-        cache.position.amount0 = uint128(cache.position.amount0 * cache.userBalance / cache.totalSupply);
-        cache.position.amount1 = uint128(cache.position.amount1 * cache.userBalance / cache.totalSupply);
-
-        // ticks not initialized or range not crossed into
-        if (cache.secondsOutsideUpper == 0
-            && cache.secondsOutsideLower == 0){
-            return (0,0,0,0,0);
+        if (cache.totalSupply > 0) {
+            cache.position.amount0 = uint128(cache.position.amount0 * cache.userBalance / cache.totalSupply);
+            cache.position.amount1 = uint128(cache.position.amount1 * cache.userBalance / cache.totalSupply);
         }
         
         cache.tick = TickMath.getTickAtSqrtRatio(cache.price);
@@ -533,7 +521,6 @@ library Positions {
             return (
                 cache.tickSecondsAccumLower - cache.tickSecondsAccumUpper,
                 cache.secondsPerLiquidityAccumLower - cache.secondsPerLiquidityAccumUpper,
-                cache.secondsOutsideLower - cache.secondsOutsideUpper,
                 cache.position.amount0,
                 cache.position.amount1
             );
@@ -561,9 +548,6 @@ library Positions {
                 cache.secondsPerLiquidityAccum
                   - cache.secondsPerLiquidityAccumLower
                   - cache.secondsPerLiquidityAccumUpper,
-                cache.blockTimestamp
-                  - cache.secondsOutsideLower
-                  - cache.secondsOutsideUpper,
                 cache.position.amount0,
                 cache.position.amount1
             );

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -98,32 +98,37 @@ library Samples {
         int24 averageTick
     ) {
         if (params.sampleLength == 0) require(false, 'InvalidSampleLength()');
-        uint256 secondsAgoLength = params.secondsAgo.length;
-        if (secondsAgoLength == 0) require(false, 'SecondsAgoArrayEmpty()');
+        if (params.secondsAgo.length == 0) require(false, 'SecondsAgoArrayEmpty()');
 
-        tickSecondsAccum = new int56[](params.secondsAgo.length);
-        secondsPerLiquidityAccum = new uint160[](params.secondsAgo.length);
+        uint256 size = params.secondsAgo.length > 1 ? params.secondsAgo.length : 2;
+        uint32[] memory secondsAgo = new uint32[](size);
+        if (params.secondsAgo.length == 1) {
+            secondsAgo = new uint32[](2);
+            secondsAgo[0] = params.secondsAgo[0];
+            secondsAgo[1] = params.secondsAgo[0] + 2;
+        }
+        else secondsAgo = params.secondsAgo;
 
-        if (params.secondsAgo.length == 1) params.secondsAgo[1] = params.secondsAgo[0] + 2;
+        tickSecondsAccum = new int56[](secondsAgo.length);
+        secondsPerLiquidityAccum = new uint160[](secondsAgo.length);
 
-        for (uint256 i = 0; i < secondsAgoLength; i++) {
-            if (i > 0 && params.secondsAgo[i] <= params.secondsAgo[i-1]) require(false, 'SecondsAgoArrayOutOfOrder()');
+        for (uint256 i = 0; i < secondsAgo.length; i++) {
+            if (i > 0 && secondsAgo[i] <= secondsAgo[i-1]) require(false, 'SecondsAgoArrayOutOfOrder()');
             (
                 tickSecondsAccum[i],
                 secondsPerLiquidityAccum[i]
             ) = getSingle(
                 IRangePool(pool),
                 params,
-                params.secondsAgo[i]
+                secondsAgo[i]
             );
         }
-        averageTick = int24((tickSecondsAccum[secondsAgoLength - 1] - tickSecondsAccum[0]) 
-                                / int32(params.secondsAgo[secondsAgoLength - 1] - params.secondsAgo[0]));
+        averageTick = int24((tickSecondsAccum[0] - tickSecondsAccum[secondsAgo.length - 1]) 
+                                / int32(secondsAgo[secondsAgo.length - 1] - secondsAgo[0]));
         averagePrice = TickMath.getSqrtRatioAtTick(averageTick);
-        averageLiquidity = uint128((secondsPerLiquidityAccum[secondsAgoLength - 1] - secondsPerLiquidityAccum[0]) 
-                                   / (params.secondsAgo[secondsAgoLength - 1] - params.secondsAgo[0]));
+        averageLiquidity = uint128((secondsPerLiquidityAccum[0] - secondsPerLiquidityAccum[secondsAgo.length - 1]) 
+                                   * (secondsAgo[secondsAgo.length - 1] - secondsAgo[0]));
     }
-
     function _poolSample(
         IRangePool pool,
         uint256 sampleIndex

--- a/contracts/libraries/Samples.sol
+++ b/contracts/libraries/Samples.sol
@@ -33,11 +33,6 @@ library Samples {
             secondsPerLiquidityAccum: 0
         });
 
-        emit SampleRecorded(
-            0,
-            0
-        );
-
         state.samples.length = 1;
         state.samples.lengthNext = 5;
 

--- a/contracts/libraries/pool/SampleCall.sol
+++ b/contracts/libraries/pool/SampleCall.sol
@@ -21,7 +21,10 @@ library SampleCall {
         uint32[] memory secondsAgo
     ) external view returns (
         int56[]   memory tickSecondsAccum,
-        uint160[] memory secondsPerLiquidityAccum
+        uint160[] memory secondsPerLiquidityAccum,
+        uint160 averagePrice,
+        uint128 averageLiquidity,
+        int24 averageTick
     ) {
         return Samples.get(
             address(this),

--- a/test/contracts/libraries/samples.ts
+++ b/test/contracts/libraries/samples.ts
@@ -1,79 +1,97 @@
-// import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
-// import { expect } from 'chai'
-// import { BigNumber } from 'ethers'
-// import { IRangePool } from '../../../typechain'
-// import { PoolState, BN_ZERO, validateMint, validateSwap } from '../../utils/contracts/rangepool'
-// import { gBefore } from '../../utils/hooks.test'
-// import { mintSigners20 } from '../../utils/token'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { BigNumber } from 'ethers'
+import { IRangePool } from '../../../typechain'
+import { PoolState, BN_ZERO, validateMint, validateSwap, getSample, validateSample, validateBurn } from '../../utils/contracts/rangepool'
+import { gBefore } from '../../utils/hooks.test'
+import { mintSigners20 } from '../../utils/token'
 
-// describe('Samples Library Tests', function () {
-//   let token0Amount: BigNumber
-//   let token1Amount: BigNumber
-//   let token0Decimals: number
-//   let token1Decimals: number
-//   let currentPrice: BigNumber
+describe('Samples Library Tests', function () {
+  let token0Amount: BigNumber
+  let token1Amount: BigNumber
+  let token0Decimals: number
+  let token1Decimals: number
+  let currentPrice: BigNumber
 
-//   let alice: SignerWithAddress
-//   let bob: SignerWithAddress
-//   let carol: SignerWithAddress
+  let alice: SignerWithAddress
+  let bob: SignerWithAddress
+  let carol: SignerWithAddress
 
-//   const tokenAmount = ethers.utils.parseUnits('100', token1Decimals)
-//   const maxPrice = BigNumber.from('1461446703485210103287273052203988822378723970341')
+  const tokenAmount = ethers.utils.parseUnits('100', token1Decimals)
+  const maxPrice = BigNumber.from('1461446703485210103287273052203988822378723970341')
 
 
 
-//   before(async function () {
-//     await gBefore()
-//     let currentBlock = await ethers.provider.getBlockNumber()
+  before(async function () {
+    await gBefore()
+    let currentBlock = await ethers.provider.getBlockNumber()
 
-//     const pool: PoolState = await hre.props.rangePool.poolState()
-//     const liquidity = pool.liquidity
-//     const price = pool.price
+    const pool: PoolState = await hre.props.rangePool.poolState()
+    const liquidity = pool.liquidity
+    const price = pool.price
 
-//     expect(liquidity).to.be.equal(BN_ZERO)
+    expect(liquidity).to.be.equal(BN_ZERO)
 
-//     currentPrice = BigNumber.from('2').pow(96)
-//     token0Decimals = await hre.props.token0.decimals()
-//     token1Decimals = await hre.props.token1.decimals()
-//     token0Amount = ethers.utils.parseUnits('100', token0Decimals)
-//     token1Amount = ethers.utils.parseUnits('100', token1Decimals)
-//     alice = hre.props.alice
-//     bob = hre.props.bob
-//     carol = hre.props.carol
+    currentPrice = BigNumber.from('2').pow(96)
+    token0Decimals = await hre.props.token0.decimals()
+    token1Decimals = await hre.props.token1.decimals()
+    token0Amount = ethers.utils.parseUnits('100', token0Decimals)
+    token1Amount = ethers.utils.parseUnits('100', token1Decimals)
+    alice = hre.props.alice
+    bob = hre.props.bob
+    carol = hre.props.carol
 
-//     await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
+    await mintSigners20(hre.props.token0, token0Amount.mul(10), [hre.props.alice, hre.props.bob])
 
-//     await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
-//   })
+    await mintSigners20(hre.props.token1, token1Amount.mul(10), [hre.props.alice, hre.props.bob])
+  })
 
-//   this.beforeEach(async function () {})
+  this.beforeEach(async function () {})
 
-// //   it('Should get accurate accumulator values', async function () {
-// //     await validateMint({
-// //         signer: hre.props.alice,
-// //         recipient: hre.props.alice.address,
-// //         lower: '10000',
-// //         upper: '20000',
-// //         amount0: tokenAmount,
-// //         amount1: tokenAmount,
-// //         fungible: true,
-// //         balance0Decrease: BigNumber.from('100000000000000000000'),
-// //         balance1Decrease: BigNumber.from('0'),
-// //         tokenAmount: BigNumber.from('170245243948753558591'),
-// //         liquidityIncrease: BigNumber.from('419027207938949970576'),
-// //         revertMessage: '',
-// //         collectRevertMessage: ''
-// //       })
+  it('Should get accurate accumulator values', async function () {
+    await validateMint({
+        signer: hre.props.alice,
+        recipient: hre.props.alice.address,
+        lower: '10000',
+        upper: '20000',
+        amount0: tokenAmount,
+        amount1: tokenAmount,
+        balance0Decrease: BigNumber.from('100000000000000000000'),
+        balance1Decrease: BigNumber.from('0'),
+        tokenAmount: BigNumber.from('170245243948753558591'),
+        liquidityIncrease: BigNumber.from('170245243948753558591'),
+        revertMessage: '',
+        collectRevertMessage: ''
+      })
   
-// //       await validateSwap({
-// //         signer: hre.props.alice,
-// //         recipient: hre.props.alice.address,
-// //         zeroForOne: false,
-// //         amountIn: tokenAmount,
-// //         sqrtPriceLimitX96: maxPrice,
-// //         balanceInDecrease: BigNumber.from('100000000000000000000'),
-// //         balanceOutIncrease: BigNumber.from('32121736932093337716'),
-// //         revertMessage: '',
-// //       })
-// //   })
-// })
+      await validateSwap({
+        signer: hre.props.alice,
+        recipient: hre.props.alice.address,
+        zeroForOne: false,
+        amountIn: tokenAmount,
+        sqrtPriceLimitX96: maxPrice,
+        balanceInDecrease: BigNumber.from('82071478085223566135'),
+        balanceOutIncrease: BigNumber.from('13496379535787307859'),
+        revertMessage: '',
+      })
+
+      await validateSample({
+        tickSecondsAccum: '1903300',
+        secondsPerLiquidityAccum: '2722258935367507707710994414499188461813',
+        averagePrice: '1461300573427867316570072651998408279850435624081',
+        averageLiquidity: '7995110090085540330',
+        averageTick: 887270
+      })
+
+      await validateBurn({
+        signer: hre.props.alice,
+        lower: '10000',
+        upper: '20000',
+        tokenAmount: BigNumber.from('170245243948753558591'),
+        liquidityAmount: BigNumber.from('170245243948753558591'),
+        balance0Increase: BigNumber.from('6751565550668988'),
+        balance1Increase: BigNumber.from('182071478085223566134'),
+        revertMessage: '',
+      })
+  })
+})

--- a/test/contracts/rangepool.ts
+++ b/test/contracts/rangepool.ts
@@ -12,8 +12,9 @@ import {
   validateBurn,
   PoolState,
   getTickAtPrice,
-  getFeeGrowthGlobal,
   getRangeBalanceOf,
+  getSnapshot,
+  getSample,
 } from '../utils/contracts/rangepool'
 
 alice: SignerWithAddress
@@ -66,7 +67,7 @@ describe('RangePool Tests', function () {
     await mintSigners20(hre.props.token1, tokenAmount.mul(10), [hre.props.alice, hre.props.bob])
   })
 
-  it('token1 - Should mint, swap, and burn', async function () {
+  it('token1 - Should mint, swap, and burn 21', async function () {
 
     await validateMint({
       signer: hre.props.alice,
@@ -92,6 +93,9 @@ describe('RangePool Tests', function () {
       revertMessage: '',
     })
 
+    if (debugMode) await getSnapshot(hre.props.alice.address, 20, 60)
+    if (debugMode) await getSample()
+
     await validateBurn({
       signer: hre.props.alice,
       lower: '20',
@@ -112,8 +116,8 @@ describe('RangePool Tests', function () {
       revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 84175109820460744055339126001827919702192640648716177173677299224470599300732, 49902591570441687020676)',
     })
 
-    if (debugMode) await getRangeBalanceOf(hre.props.alice, 20, 60)
-
+    if (debugMode) await getRangeBalanceOf(hre.props.alice.address, 20, 60)
+    if (debugMode) await getSnapshot(hre.props.alice.address, 20, 60)
     await validateBurn({
       signer: hre.props.alice,
       lower: '20',
@@ -123,10 +127,11 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('89946873348418057510'),
       revertMessage: '',
     })
-    
+    if (debugMode) await getSample()
+    if (debugMode) await getSnapshot(hre.props.alice.address, 20, 60)
     if (debugMode){
       console.log('after burn')
-      await getRangeBalanceOf(hre.props.alice, 20, 60)
+      await getRangeBalanceOf(hre.props.alice.address, 20, 60)
     }
 
     if (balanceCheck) {
@@ -170,8 +175,9 @@ describe('RangePool Tests', function () {
 
     if (debugMode) await getTickAtPrice()
 
-    if (debugMode) await getRangeBalanceOf(hre.props.alice, 20, 60)
-
+    if (debugMode) await getRangeBalanceOf(hre.props.alice.address, 20, 60)
+    if (debugMode) await getSnapshot(hre.props.alice.address, 20, 60)
+    if (debugMode) await getSample()
     await validateBurn({
       signer: hre.props.alice,
       lower: '20',
@@ -184,7 +190,7 @@ describe('RangePool Tests', function () {
 
     if (debugMode){
       console.log('after burn')
-      await getRangeBalanceOf(hre.props.alice, 20, 60)
+      await getRangeBalanceOf(hre.props.alice.address, 20, 60)
     }
 
     if (balanceCheck) {
@@ -254,9 +260,9 @@ describe('RangePool Tests', function () {
       balance1Increase: BN_ZERO,
       revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 6218138040528368831964571869767811158861841082162340705251949460170393461339, 419027207938949970577)',
     })
-
-    if (debugMode) await getRangeBalanceOf(hre.props.alice, 10000, 20000)
-
+    if (debugMode) await getSample()
+    if (debugMode) await getRangeBalanceOf(hre.props.alice.address, 10000, 20000)
+    if (debugMode) await getSnapshot(hre.props.alice.address, 10000, 20000)
     await validateBurn({
       signer: hre.props.alice,
       lower: '10000',
@@ -311,9 +317,9 @@ describe('RangePool Tests', function () {
       balance1Increase: BN_ZERO,
       revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 2236771031221735906744102008774832778161797975119947154210717982934819779160, 419027207938949970577)',
     })
-
+    if (debugMode) await getSample()
     if (debugMode) await getTickAtPrice()
-
+    if (debugMode) await getSnapshot(hre.props.alice.address, 10000, 20000)
     await validateBurn({
       signer: hre.props.alice,
       lower: '10000',
@@ -358,9 +364,9 @@ describe('RangePool Tests', function () {
       balanceOutIncrease: BigNumber.from('1345645380966504669'),
       revertMessage: '',
     })
-
-    if (debugMode) await getRangeBalanceOf(hre.props.alice, 25000, 30000)
-
+    if (debugMode) await getSample()
+    if (debugMode) await getRangeBalanceOf(hre.props.alice.address, 25000, 30000)
+    if (debugMode) await getSnapshot(hre.props.alice.address, 20000, 30000)
     await validateBurn({
       signer: hre.props.alice,
       lower: '20000',
@@ -406,6 +412,8 @@ describe('RangePool Tests', function () {
       revertMessage: '',
     })
 
+    if (debugMode) await getSnapshot(hre.props.alice.address, 25000, 30000)
+
     await validateMint({
       signer: hre.props.alice,
       recipient: hre.props.alice.address,
@@ -429,9 +437,9 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('20082623526365456123'),
       revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 57647542114002963046563858950471683132924844866766617044886400134835958049633, 3168808846234106973666)',
     })
-
-    if (debugMode) await getRangeBalanceOf(hre.props.alice, 25000, 30000)
-
+    if (debugMode) await getSample()
+    if (debugMode) await getRangeBalanceOf(hre.props.alice.address, 25000, 30000)
+    if (debugMode) await getSnapshot(hre.props.alice.address, 25000, 30000)
     await validateBurn({
       signer: hre.props.alice,
       lower: '25000',
@@ -504,7 +512,8 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('144243177493286617044'),
       revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 2381093050879867228278279701469820094323623974324911225843268442440969283554, 11988250493261524638130)',
     })
-
+    if (debugMode) await getSnapshot(hre.props.alice.address, 500, 1000)
+    if (debugMode) await getSample()
     await validateBurn({
       signer: hre.props.alice,
       lower: '500',
@@ -563,7 +572,7 @@ describe('RangePool Tests', function () {
       balanceOutIncrease: BigNumber.from('27122499921707680271'),
       revertMessage: '',
     })
-
+    if (debugMode) await getSample()
     await validateSwap({
       signer: hre.props.alice,
       recipient: hre.props.alice.address,
@@ -574,7 +583,7 @@ describe('RangePool Tests', function () {
       balanceOutIncrease: BigNumber.from('78764658213120928119'),
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.alice.address, 500, 1000)
     await validateMint({
       signer: hre.props.alice,
       recipient: hre.props.alice.address,
@@ -600,7 +609,7 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('144243177493286617045'),
       revertMessage: 'BurnExceedsBalance("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 2381093050879867228278279701469820094323623974324911225843268442440969283554, 11557073070124432353430)'
     })
-
+    if (debugMode) await getSnapshot(hre.props.alice.address, 500, 1000)
     await validateBurn({
       signer: hre.props.alice,
       lower: '500',
@@ -611,7 +620,7 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('300013568033977842760'),
       revertMessage: '',
     })
-
+    if (debugMode) await getSample()
     if (balanceCheck) {
       console.log('balance after token0:', (await hre.props.token0.balanceOf(hre.props.rangePool.address)).toString())
       console.log('balance after token1:', (await hre.props.token1.balanceOf(hre.props.rangePool.address)).toString())
@@ -662,7 +671,7 @@ describe('RangePool Tests', function () {
       liquidityIncrease: BigNumber.from('4901161634764542438934'),
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.alice.address, 200, 600)
     await validateBurn({
       signer: hre.props.bob,
       lower: '200',
@@ -673,7 +682,7 @@ describe('RangePool Tests', function () {
       balance1Increase: tokenAmount.sub(1),
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.alice.address, 500, 1000)
     await validateBurn({
       signer: hre.props.alice,
       lower: '500',
@@ -736,7 +745,7 @@ describe('RangePool Tests', function () {
       liquidityIncrease: bobLiquidity,
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.bob.address, 600, 800)
     await validateBurn({
       signer: hre.props.bob,
       lower: '600',
@@ -747,7 +756,7 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('38018615604156121196'),
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.bob.address, 600, 800)
     await validateBurn({
       signer: hre.props.bob,
       lower: '600',
@@ -758,7 +767,7 @@ describe('RangePool Tests', function () {
       balance1Increase: BigNumber.from('61981384395843878803'),
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.alice.address, 500, 1000)
     await validateBurn({
       signer: hre.props.alice,
       lower: '500',
@@ -832,7 +841,7 @@ describe('RangePool Tests', function () {
       liquidityIncrease: bobLiquidity,
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.bob.address, 600, 800)
     await validateBurn({
       signer: hre.props.bob,
       lower: '600',
@@ -843,7 +852,7 @@ describe('RangePool Tests', function () {
       balance1Increase: BN_ZERO,
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.bob.address, 600, 800)
     await validateBurn({
       signer: hre.props.bob,
       lower: '600',
@@ -854,7 +863,7 @@ describe('RangePool Tests', function () {
       balance1Increase: BN_ZERO,
       revertMessage: '',
     })
-
+    if (debugMode) await getSnapshot(hre.props.alice.address, 500, 1000)
     await validateBurn({
       signer: hre.props.alice,
       lower: '500',

--- a/test/utils/contracts/rangepool.ts
+++ b/test/utils/contracts/rangepool.ts
@@ -94,28 +94,40 @@ export interface ValidateBurnParams {
   revertMessage: string
 }
 
-// export async function getTickAtPrice() {
-//   const price = (await hre.props.rangePool.poolState()).price
-//   const tick = await hre.props.tickMathLib.getTickAtSqrtRatio(price)
-//   console.log('tick at price:', tick)
-// }
+export async function getTickAtPrice() {
+  const tickAtPrice = (await hre.props.rangePool.poolState()).tickAtPrice
+  console.log('tick at price:', tickAtPrice)
+}
 
-export async function getRangeBalanceOf(owner: SignerWithAddress, lower: number, upper: number): Promise<BigNumber> {
+export async function getRangeBalanceOf(owner: string, lower: number, upper: number): Promise<BigNumber> {
   const positionTokenId  = await hre.props.positionsLib.id(lower, upper);
-  const balance = await hre.props.rangePool.balanceOf(owner.address, positionTokenId)
+  const balance = await hre.props.rangePool.balanceOf(owner, positionTokenId)
   console.log('position token balance')
   console.log('----------------------')
-  console.log('owner:', owner.address)
+  console.log('owner:', owner)
   console.log('balance:', balance.toString())
   return balance
 }
 
-// export async function getFeeGrowthGlobal(isToken0: boolean = true) {
-//   const price = isToken0 ? (await hre.props.rangePool.poolState()).feeGrowthGlobal0
-//                          : (await hre.props.rangePool.poolState()).feeGrowthGlobal1
-//   const tick = await hre.props.tickMathLib.getTickAtSqrtRatio(price)
-//   console.log('fee growth', isToken0 ? '0:' : '1:', tick)
-// }
+export async function getSnapshot(owner: string, lower: number, upper: number) {
+  const snapshot = await hre.props.rangePool.snapshot({
+    owner: owner,
+    lower: lower,
+    upper: upper
+  })
+  console.log('snapshot for ', owner, lower, upper, ':')
+  console.log('feesOwed0:', snapshot.feesOwed0.toString())
+  console.log('feesOwed1:', snapshot.feesOwed1.toString())
+  console.log()
+}
+
+export async function getSample() {
+  const sample = await hre.props.rangePool.sample([0])
+  console.log('sample for [0]:')
+  console.log('average liquidity:', sample.averageLiquidity.toString())
+  console.log('average price:', sample.averagePrice.toString())
+  console.log('average tick:', sample.averageTick.toString())
+}
 
 export async function validateSwap(params: ValidateSwapParams) {
   const signer = params.signer

--- a/test/utils/contracts/rangepool.ts
+++ b/test/utils/contracts/rangepool.ts
@@ -72,6 +72,14 @@ export interface ValidateMintParams {
   balanceCheck?: boolean
 }
 
+export interface ValidateSampleParams {
+  secondsPerLiquidityAccum: string
+  tickSecondsAccum: string
+  averagePrice: string
+  averageLiquidity: string
+  averageTick: number
+}
+
 export interface ValidateSwapParams {
   signer: SignerWithAddress
   recipient: string
@@ -121,12 +129,31 @@ export async function getSnapshot(owner: string, lower: number, upper: number) {
   console.log()
 }
 
-export async function getSample() {
+export async function getSample(print = false) {
   const sample = await hre.props.rangePool.sample([0])
-  console.log('sample for [0]:')
-  console.log('average liquidity:', sample.averageLiquidity.toString())
-  console.log('average price:', sample.averagePrice.toString())
-  console.log('average tick:', sample.averageTick.toString())
+  if(print) {
+    console.log('sample for [0]:')
+    console.log('average liquidity:', sample.averageLiquidity.toString())
+    console.log('average price:', sample.averagePrice.toString())
+    console.log('average tick:', sample.averageTick.toString())
+  }
+  return sample
+}
+
+export async function validateSample(params: ValidateSampleParams) {
+  const secondsPerLiquidityAccum = params.secondsPerLiquidityAccum
+  const tickSecondsAccum = BigNumber.from(params.tickSecondsAccum)
+  const averagePrice = BigNumber.from(params.averagePrice)
+  const averageTick = BigNumber.from(params.averageTick)
+  const averageLiquidity = BigNumber.from(params.averageLiquidity)
+
+  const sample = await getSample()
+
+  expect(sample.secondsPerLiquidityAccum[0]).to.be.equal(secondsPerLiquidityAccum)
+  expect(sample.tickSecondsAccum[0]).to.be.equal(tickSecondsAccum)
+  expect(sample.averagePrice).to.be.equal(averagePrice)
+  expect(sample.averageTick).to.be.equal(averageTick)
+  expect(sample.averageLiquidity).to.be.equal(averageLiquidity)
 }
 
 export async function validateSwap(params: ValidateSwapParams) {


### PR DESCRIPTION
This PR adds extra return values to the `samples()` function to reduce calculations on the TWAP data consumer side.

* average tick between first and last index of `secondsAgo` array
* average sqrt price between first and last index of `secondsAgo` array
* average liquidity constant between first and last index of `secondsAgo` array

