### PR TITLE
Scroll alpha deployment; `secondsAgo` ordering less strict

### DIFF
--- a/scripts/autogen/contract-deployments-keys.ts
+++ b/scripts/autogen/contract-deployments-keys.ts
@@ -5,4 +5,48 @@ export const CONTRACT_DEPLOYMENT_KEYS: ContractDeploymentsKey[] = [
         networkName: 'scroll_alpha',
         objectName: 'rangePool'
     },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'tickMathLib'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'ticksLib'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'positionsLib'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'mintCall'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'burnCall'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'swapCall'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'quoteCall'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'sampleCall'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'rangePoolManager'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'rangePoolFactory'
+    },
+    {
+        networkName: 'scroll_alpha',
+        objectName: 'rangePool'
+    },
 ];

--- a/scripts/autogen/contract-deployments.json
+++ b/scripts/autogen/contract-deployments.json
@@ -222,66 +222,78 @@
         },
         "tickMathLib": {
             "contractName": "TickMath",
-            "contractAddress": "0x38CB66EA3D5B5341201E6A0B1b150660880e7d5d",
+            "contractAddress": "0x139e58aCA96cd776E3d8E3e20dFC30154C485b46",
             "constructorArguments": [],
-            "created": "2023-05-28T00:42:57.358Z"
+            "created": "2023-06-04T18:12:53.520Z"
         },
         "ticksLib": {
             "contractName": "Ticks",
-            "contractAddress": "0xE35d5Aa1Bac86d9eEaEf63E7013094192e57eD21",
+            "contractAddress": "0x358242AAC3E75dA72A4c091c091C80a84f115966",
             "constructorArguments": [],
-            "created": "2023-05-28T00:43:07.853Z"
+            "created": "2023-06-04T18:13:02.859Z"
         },
         "positionsLib": {
             "contractName": "Positions",
-            "contractAddress": "0xC2271A012fbBA8098e569bE9fA893a1255D73b0f",
+            "contractAddress": "0x5f7d98A4443517C3928cb925D7202412B1E34886",
             "constructorArguments": [],
-            "created": "2023-05-28T00:43:14.098Z"
+            "created": "2023-06-04T18:13:12.017Z"
         },
         "mintCall": {
             "contractName": "MintCall",
-            "contractAddress": "0x4372EE46DfB52d271139Fd40AeDa61c5da0c35E5",
+            "contractAddress": "0xEf8BE53E21994fA411c1a6fb9cbc9c8Ad6125F52",
             "constructorArguments": [],
-            "created": "2023-05-28T00:43:21.122Z"
+            "created": "2023-06-04T18:13:17.144Z"
         },
         "burnCall": {
             "contractName": "BurnCall",
-            "contractAddress": "0x1Fc002005790e473B2cD4f93f1D24A20432dA75D",
+            "contractAddress": "0x33dF95EFE07a3b3E69bA31438ae511D360D89b32",
             "constructorArguments": [],
-            "created": "2023-05-28T00:43:31.729Z"
+            "created": "2023-06-04T18:13:26.875Z"
         },
         "swapCall": {
             "contractName": "SwapCall",
-            "contractAddress": "0x0bDcD4D288eB481Dd3cD81a2A35aD68CD5dED30D",
+            "contractAddress": "0x62e0671022aF1B2E705f08B282767c57D29c7c4c",
             "constructorArguments": [],
-            "created": "2023-05-28T00:43:38.616Z"
+            "created": "2023-06-04T18:13:36.622Z"
         },
         "rangePoolManager": {
             "contractName": "RangePoolManager",
-            "contractAddress": "0x29f6547dd4ba11E169173c8D210dB7138D09054f",
+            "contractAddress": "0x5F6dE12756B3e6Df4Db21Bcc4855b4EB52a5D794",
             "constructorArguments": [],
-            "created": "2023-05-28T00:43:44.734Z"
+            "created": "2023-06-04T18:13:56.778Z"
         },
         "rangePoolFactory": {
             "contractName": "RangePoolFactory",
-            "contractAddress": "0x599372aBEd45A59140d85Cc25618381103C245fA",
+            "contractAddress": "0xD47965e2357F60B4E2062dF945Afdcc655B5ce3a",
             "constructorArguments": [
-                "0x29f6547dd4ba11E169173c8D210dB7138D09054f"
+                "0x5F6dE12756B3e6Df4Db21Bcc4855b4EB52a5D794"
             ],
-            "created": "2023-05-28T00:43:55.682Z"
+            "created": "2023-06-04T18:14:02.608Z"
         },
         "rangePool": {
             "contractName": "RangePool",
-            "contractAddress": "0xCbdcDC82bDCc94F576e9d62a1F67046a2c6A2864",
+            "contractAddress": "0xc7c3b221033d5a19Fe8150E1E8340f5121524876",
             "constructorArguments": [
                 "0x8E40c68b7546efd009a1A300C92e25Da3c8725dc",
                 "0xe0C1E03B85b22e10718cb20c3e91Dd34dd73905e",
-                "0x29f6547dd4ba11E169173c8D210dB7138D09054f",
+                "0x5F6dE12756B3e6Df4Db21Bcc4855b4EB52a5D794",
                 "177159557114295710296101716160",
                 "10",
                 "500"
             ],
-            "created": "2023-05-28T00:44:10.455Z"
+            "created": "2023-06-04T18:14:17.981Z"
+        },
+        "quoteCall": {
+            "contractName": "QuoteCall",
+            "contractAddress": "0xcD453B942f35adf0364D89c05a892518825c1c3b",
+            "constructorArguments": [],
+            "created": "2023-06-04T18:13:41.953Z"
+        },
+        "sampleCall": {
+            "contractName": "SampleCall",
+            "contractAddress": "0x61E80B7f57f3613ce30153c85D29aD571e7e9032",
+            "constructorArguments": [],
+            "created": "2023-06-04T18:13:47.035Z"
         }
     }
 }

--- a/tasks/deploy/utils/mintPosition.ts
+++ b/tasks/deploy/utils/mintPosition.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers'
-import { BN_ZERO, getRangeBalanceOf, validateBurn, validateMint, validateSwap } from '../../../test/utils/contracts/rangepool'
+import { BN_ZERO, getRangeBalanceOf, getSample, getSnapshot, validateBurn, validateMint, validateSwap } from '../../../test/utils/contracts/rangepool'
 import { InitialSetup } from '../../../test/utils/setup/initialSetup'
 import { mintSigners20 } from '../../../test/utils/token'
 import { getNonce } from '../../utils'
@@ -46,6 +46,7 @@ export class MintPosition {
     //   balanceOutIncrease: token1Amount.mul(30),
     //   revertMessage:''
     // })
+    await getSample(true)
     // await validateMint({
     //   signer: hre.props.alice,
     //   recipient: hre.props.alice.address,
@@ -101,18 +102,18 @@ export class MintPosition {
     //   revertMessage: '',
     // })
 
-    let balance = await getRangeBalanceOf(hre.props.alice, -887270, 887270)
+    // let balance = await getRangeBalanceOf(hre.props.alice, -887270, 887270)
 
-    await validateBurn({
-      signer: hre.props.alice,
-      lower: '-887270',
-      upper: '887270',
-      tokenAmount: balance.div(2),
-      liquidityAmount: balance.div(2),
-      balance0Increase: BigNumber.from('110739133337787245411'),
-      balance1Increase: BigNumber.from('49999999999999999'),
-      revertMessage: '',
-    })
+    // await validateBurn({
+    //   signer: hre.props.alice,
+    //   lower: '-887270',
+    //   upper: '887270',
+    //   tokenAmount: balance.div(2),
+    //   liquidityAmount: balance.div(2),
+    //   balance0Increase: BigNumber.from('110739133337787245411'),
+    //   balance1Increase: BigNumber.from('49999999999999999'),
+    //   revertMessage: '',
+    // })
 
     console.log('position minted', (await hre.props.rangePool.poolState()).price.toString())
   }

--- a/test/utils/contracts/rangepool.ts
+++ b/test/utils/contracts/rangepool.ts
@@ -171,11 +171,13 @@ export async function validateSwap(params: ValidateSwapParams) {
   if (zeroForOne) {
     balanceInBefore = await hre.props.token0.balanceOf(signer.address)
     balanceOutBefore = await hre.props.token1.balanceOf(signer.address)
-    await hre.props.token0.approve(hre.props.rangePool.address, amountIn)
+    const approve0Txn = await hre.props.token0.approve(hre.props.rangePool.address, amountIn)
+    await approve0Txn.wait()
   } else {
     balanceInBefore = await hre.props.token1.balanceOf(signer.address)
     balanceOutBefore = await hre.props.token0.balanceOf(signer.address)
-    await hre.props.token1.approve(hre.props.rangePool.address, amountIn)
+    const approve1Txn = await hre.props.token1.approve(hre.props.rangePool.address, amountIn)
+    await approve1Txn.wait()
   }
 
   const poolBefore: PoolState = await hre.props.rangePool.poolState()
@@ -262,13 +264,13 @@ export async function validateMint(params: ValidateMintParams) {
   //collect first to recreate positions if necessary
   if (!collectRevertMessage) {
     const txn = await hre.props.rangePool
-      .connect(params.signer)
+      .connect(signer)
       .burn({
         to: signer.address, 
         lower: lower, 
         upper: upper,
         amount: '0',
-      })
+      }, {gasLimit: 3000000})
     await txn.wait()
   } else {
     await expect(
@@ -285,12 +287,14 @@ export async function validateMint(params: ValidateMintParams) {
   let balance1Before
   balance0Before = await hre.props.token0.balanceOf(params.signer.address)
   balance1Before = await hre.props.token1.balanceOf(params.signer.address)
-  await hre.props.token0
+  const approve0Txn = await hre.props.token0
     .connect(params.signer)
     .approve(hre.props.rangePool.address, amount0)
-  await hre.props.token1
+  await approve0Txn.wait()
+  const approve1Txn = await hre.props.token1
     .connect(params.signer)
     .approve(hre.props.rangePool.address, amount1)
+  await approve1Txn.wait()
 
   let lowerTickBefore: Tick
   let upperTickBefore: Tick

--- a/test/utils/setup/initialSetup.ts
+++ b/test/utils/setup/initialSetup.ts
@@ -37,24 +37,24 @@ export class InitialSetup {
   public async initialRangePoolSetup(): Promise<number> {
     const network = SUPPORTED_NETWORKS[hre.network.name.toUpperCase()]
 
-    // const token0Address = (
-    //   await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
-    //     {
-    //       networkName: hre.network.name,
-    //       objectName: 'token0',
-    //     },
-    //     'readRangePoolSetup'
-    //   )
-    // ).contractAddress
-    // const token1Address = (
-    //   await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
-    //     {
-    //       networkName: hre.network.name,
-    //       objectName: 'token1',
-    //     },
-    //     'readRangePoolSetup'
-    //   )
-    // ).contractAddress
+    const token0Address = (
+      await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
+        {
+          networkName: hre.network.name,
+          objectName: 'token0',
+        },
+        'readRangePoolSetup'
+      )
+    ).contractAddress
+    const token1Address = (
+      await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
+        {
+          networkName: hre.network.name,
+          objectName: 'token1',
+        },
+        'readRangePoolSetup'
+      )
+    ).contractAddress
     // const tickMathLib = (
     //   await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
     //     {
@@ -101,60 +101,60 @@ export class InitialSetup {
     //   )
     // ).contractAddress
 
-    // hre.props.token0 = await hre.ethers.getContractAt('Token20', token0Address)
-    // hre.props.token1 = await hre.ethers.getContractAt('Token20', token1Address)
+    hre.props.token0 = await hre.ethers.getContractAt('Token20', token0Address)
+    hre.props.token1 = await hre.ethers.getContractAt('Token20', token1Address)
     // hre.props.tickMathLib = await hre.ethers.getContractAt('TickMath', tickMathLib)
     // hre.props.precisionMathLib = await hre.ethers.getContractAt('PrecisionMath', precisionMathLib)
     // hre.props.dydxMathLib = await hre.ethers.getContractAt('DyDxMath', dydxMathLib)
     // hre.props.tickMapLib = await hre.ethers.getContractAt('TickMap', tickMapLib)
     // hre.props.samplesLib = await hre.ethers.getContractAt('Samples', samplesLib)
 
-    await this.deployAssist.deployContractWithRetry(
-      network,
-      // @ts-ignore
-      Token20__factory,
-      'tokenA',
-      ['Token20A', 'TOKEN20A', this.token0Decimals]
-    )
+    // await this.deployAssist.deployContractWithRetry(
+    //   network,
+    //   // @ts-ignore
+    //   Token20__factory,
+    //   'tokenA',
+    //   ['Token20A', 'TOKEN20A', this.token0Decimals]
+    // )
 
-    await this.deployAssist.deployContractWithRetry(
-      network,
-      // @ts-ignore
-      Token20__factory,
-      'tokenB',
-      ['Token20B', 'TOKEN20B', this.token1Decimals]
-    )
+    // await this.deployAssist.deployContractWithRetry(
+    //   network,
+    //   // @ts-ignore
+    //   Token20__factory,
+    //   'tokenB',
+    //   ['Token20B', 'TOKEN20B', this.token1Decimals]
+    // )
 
-    const tokenOrder = hre.props.tokenA.address.localeCompare(hre.props.tokenB.address)
-    let token0Args
-    let token1Args
-    if (tokenOrder < 0) {
-      hre.props.token0 = hre.props.tokenA
-      hre.props.token1 = hre.props.tokenB
-      token0Args = ['Token20A', 'TOKEN20A', this.token0Decimals]
-      token1Args = ['Token20B', 'TOKEN20B', this.token1Decimals]
-    } else {
-      hre.props.token0 = hre.props.tokenB
-      hre.props.token1 = hre.props.tokenA
-      token0Args = ['Token20B', 'TOKEN20B', this.token1Decimals]
-      token1Args = ['Token20A', 'TOKEN20A', this.token0Decimals]
-    }
-    this.deployAssist.saveContractDeployment(
-      network,
-      'Token20',
-      'token0',
-      hre.props.token0,
-      token0Args
-    )
-    this.deployAssist.saveContractDeployment(
-      network,
-      'Token20',
-      'token1',
-      hre.props.token1,
-      token1Args
-    )
-    this.deployAssist.deleteContractDeployment(network, 'tokenA')
-    this.deployAssist.deleteContractDeployment(network, 'tokenB')
+    // const tokenOrder = hre.props.tokenA.address.localeCompare(hre.props.tokenB.address)
+    // let token0Args
+    // let token1Args
+    // if (tokenOrder < 0) {
+    //   hre.props.token0 = hre.props.tokenA
+    //   hre.props.token1 = hre.props.tokenB
+    //   token0Args = ['Token20A', 'TOKEN20A', this.token0Decimals]
+    //   token1Args = ['Token20B', 'TOKEN20B', this.token1Decimals]
+    // } else {
+    //   hre.props.token0 = hre.props.tokenB
+    //   hre.props.token1 = hre.props.tokenA
+    //   token0Args = ['Token20B', 'TOKEN20B', this.token1Decimals]
+    //   token1Args = ['Token20A', 'TOKEN20A', this.token0Decimals]
+    // }
+    // this.deployAssist.saveContractDeployment(
+    //   network,
+    //   'Token20',
+    //   'token0',
+    //   hre.props.token0,
+    //   token0Args
+    // )
+    // this.deployAssist.saveContractDeployment(
+    //   network,
+    //   'Token20',
+    //   'token1',
+    //   hre.props.token1,
+    //   token1Args
+    // )
+    // this.deployAssist.deleteContractDeployment(network, 'tokenA')
+    // this.deployAssist.deleteContractDeployment(network, 'tokenB')
 
     await this.deployAssist.deployContractWithRetry(
       network,

--- a/test/utils/setup/initialSetup.ts
+++ b/test/utils/setup/initialSetup.ts
@@ -37,24 +37,24 @@ export class InitialSetup {
   public async initialRangePoolSetup(): Promise<number> {
     const network = SUPPORTED_NETWORKS[hre.network.name.toUpperCase()]
 
-    const token0Address = (
-      await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
-        {
-          networkName: hre.network.name,
-          objectName: 'token0',
-        },
-        'readRangePoolSetup'
-      )
-    ).contractAddress
-    const token1Address = (
-      await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
-        {
-          networkName: hre.network.name,
-          objectName: 'token1',
-        },
-        'readRangePoolSetup'
-      )
-    ).contractAddress
+    // const token0Address = (
+    //   await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
+    //     {
+    //       networkName: hre.network.name,
+    //       objectName: 'token0',
+    //     },
+    //     'readRangePoolSetup'
+    //   )
+    // ).contractAddress
+    // const token1Address = (
+    //   await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
+    //     {
+    //       networkName: hre.network.name,
+    //       objectName: 'token1',
+    //     },
+    //     'readRangePoolSetup'
+    //   )
+    // ).contractAddress
     // const tickMathLib = (
     //   await this.contractDeploymentsJson.readContractDeploymentsJsonFile(
     //     {
@@ -101,60 +101,60 @@ export class InitialSetup {
     //   )
     // ).contractAddress
 
-    hre.props.token0 = await hre.ethers.getContractAt('Token20', token0Address)
-    hre.props.token1 = await hre.ethers.getContractAt('Token20', token1Address)
+    // hre.props.token0 = await hre.ethers.getContractAt('Token20', token0Address)
+    // hre.props.token1 = await hre.ethers.getContractAt('Token20', token1Address)
     // hre.props.tickMathLib = await hre.ethers.getContractAt('TickMath', tickMathLib)
     // hre.props.precisionMathLib = await hre.ethers.getContractAt('PrecisionMath', precisionMathLib)
     // hre.props.dydxMathLib = await hre.ethers.getContractAt('DyDxMath', dydxMathLib)
     // hre.props.tickMapLib = await hre.ethers.getContractAt('TickMap', tickMapLib)
     // hre.props.samplesLib = await hre.ethers.getContractAt('Samples', samplesLib)
 
-    // await this.deployAssist.deployContractWithRetry(
-    //   network,
-    //   // @ts-ignore
-    //   Token20__factory,
-    //   'tokenA',
-    //   ['Token20A', 'TOKEN20A', this.token0Decimals]
-    // )
+    await this.deployAssist.deployContractWithRetry(
+      network,
+      // @ts-ignore
+      Token20__factory,
+      'tokenA',
+      ['Token20A', 'TOKEN20A', this.token0Decimals]
+    )
 
-    // await this.deployAssist.deployContractWithRetry(
-    //   network,
-    //   // @ts-ignore
-    //   Token20__factory,
-    //   'tokenB',
-    //   ['Token20B', 'TOKEN20B', this.token1Decimals]
-    // )
+    await this.deployAssist.deployContractWithRetry(
+      network,
+      // @ts-ignore
+      Token20__factory,
+      'tokenB',
+      ['Token20B', 'TOKEN20B', this.token1Decimals]
+    )
 
-    // const tokenOrder = hre.props.tokenA.address.localeCompare(hre.props.tokenB.address)
-    // let token0Args
-    // let token1Args
-    // if (tokenOrder < 0) {
-    //   hre.props.token0 = hre.props.tokenA
-    //   hre.props.token1 = hre.props.tokenB
-    //   token0Args = ['Token20A', 'TOKEN20A', this.token0Decimals]
-    //   token1Args = ['Token20B', 'TOKEN20B', this.token1Decimals]
-    // } else {
-    //   hre.props.token0 = hre.props.tokenB
-    //   hre.props.token1 = hre.props.tokenA
-    //   token0Args = ['Token20B', 'TOKEN20B', this.token1Decimals]
-    //   token1Args = ['Token20A', 'TOKEN20A', this.token0Decimals]
-    // }
-    // this.deployAssist.saveContractDeployment(
-    //   network,
-    //   'Token20',
-    //   'token0',
-    //   hre.props.token0,
-    //   token0Args
-    // )
-    // this.deployAssist.saveContractDeployment(
-    //   network,
-    //   'Token20',
-    //   'token1',
-    //   hre.props.token1,
-    //   token1Args
-    // )
-    // this.deployAssist.deleteContractDeployment(network, 'tokenA')
-    // this.deployAssist.deleteContractDeployment(network, 'tokenB')
+    const tokenOrder = hre.props.tokenA.address.localeCompare(hre.props.tokenB.address)
+    let token0Args
+    let token1Args
+    if (tokenOrder < 0) {
+      hre.props.token0 = hre.props.tokenA
+      hre.props.token1 = hre.props.tokenB
+      token0Args = ['Token20A', 'TOKEN20A', this.token0Decimals]
+      token1Args = ['Token20B', 'TOKEN20B', this.token1Decimals]
+    } else {
+      hre.props.token0 = hre.props.tokenB
+      hre.props.token1 = hre.props.tokenA
+      token0Args = ['Token20B', 'TOKEN20B', this.token1Decimals]
+      token1Args = ['Token20A', 'TOKEN20A', this.token0Decimals]
+    }
+    this.deployAssist.saveContractDeployment(
+      network,
+      'Token20',
+      'token0',
+      hre.props.token0,
+      token0Args
+    )
+    this.deployAssist.saveContractDeployment(
+      network,
+      'Token20',
+      'token1',
+      hre.props.token1,
+      token1Args
+    )
+    this.deployAssist.deleteContractDeployment(network, 'tokenA')
+    this.deployAssist.deleteContractDeployment(network, 'tokenB')
 
     await this.deployAssist.deployContractWithRetry(
       network,


### PR DESCRIPTION
This PR adds the latest deployment for Scroll testnet.

It also makes the `secondsAgo` ordering less strict.

The first and last index passed cannot be equal.

Other than that, any values will be accepted for the `secondsAgo` array.